### PR TITLE
Setup unit testing capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ target
 google.json
 venv
 *.pyc
+.DS_STORE

--- a/py/README.md
+++ b/py/README.md
@@ -18,11 +18,13 @@ Ensure you have `mysql` plus command line tools setup:
 mysql
 mysql> CREATE DATABASE pcasts_db_dev CHARACTER SET utf8mb4;
 mysql> CREATE DATABASE pcasts_podcast_db_dev CHARACTER SET utf8mb4;
+mysql> CREATE DATABASE test_pcasts_db_dev CHARACTER SET utf8mb4;
+mysql> CREATE DATABASE test_pcasts_podcast_db_dev CHARACTER SET utf8mb4;
 mysql> \q
-cd src
-python manage.py db init --multidb # Generate migrations folder
-python manage.py db migrate # Migrates the DB
-python manage.py db upgrade # Upgrades the DB
+cd src/scripts
+
+python setup_db.py dev
+python setup_db.py test
 ````
 
 If the `migrations` directory is ever deleted, you can regenerate it with the following:
@@ -45,6 +47,14 @@ PODCAST_DB_USERNAME
 PODCAST_DB_PASSWORD
 PODCAST_DB_HOST
 PODCAST_DB_NAME
+TEST_DB_USERNAME
+TEST_DB_PASSWORD
+TEST_DB_HOST
+TEST_DB_NAME
+TEST_PODCAST_DB_USERNAME
+TEST_PODCAST_DB_PASSWORD
+TEST_PODCAST_DB_HOST
+TEST_PODCAST_DB_NAME
 APP_SETTINGS # e.g. config.DevelopmentConfig
 ````
 
@@ -58,7 +68,31 @@ export PODCAST_DB_USERNAME=CHANGEME
 export PODCAST_DB_PASSWORD=CHANGEME
 export PODCAST_DB_HOST=localhost
 export PODCAST_DB_NAME=pcasts_podcast_db_dev
-export APP_SETTINGS=CHANGEME
+export TEST_DB_USERNAME=CHANGEME
+export TEST_DB_PASSWORD=CHANGEME
+export TEST_DB_HOST=localhost
+export TEST_DB_NAME=test_pcasts_db_dev
+export TEST_PODCAST_DB_USERNAME=CHANGEME
+export TEST_PODCAST_DB_PASSWORD=CHANGEME
+export TEST_PODCAST_DB_HOST=localhost
+export TEST_PODCAST_DB_NAME=test_pcasts_podcast_db_dev
+export APP_SETTINGS=config.DevelopmentConfig
 ````
 
+In the `/tests` directory, create another `.env` file that changes the `APP_SETTINGS`:
+````bash
+export APP_SETTINGS=config.TestingConfig
+````
 ## Loading in Test Data
+From the `/py` directory, run:
+````
+python src/scripts/load_data.py dev
+python src/scripts/load_data.py test
+````
+
+## Testing
+To run unit tests, from the `/tests` directory, run
+````
+nosetests
+````
+to run all of the tests in the directory.

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,5 +1,6 @@
 alembic==0.9.5
 appdev.py==0.0.1
+autoenv==1.0.0
 certifi==2017.7.27.1
 chardet==3.0.4
 click==6.7
@@ -16,6 +17,7 @@ marshmallow==2.13.6
 marshmallow-sqlalchemy==0.13.1
 mysql==0.0.1
 MySQL-python==1.2.5
+nose==1.3.7
 python-dateutil==2.6.1
 python-editor==1.0.3
 requests==2.18.4

--- a/py/src/config.py
+++ b/py/src/config.py
@@ -27,6 +27,30 @@ PODCAST_DB_URL      = 'mysql://{}:{}@{}/{}?charset=utf8mb4'.format(
   PODCAST_DB_NAME
 )
 
+# Analog of database for testing purposes
+TEST_DB_USERNAME  = os.environ['TEST_DB_USERNAME']
+TEST_DB_PASSWORD  = os.environ['TEST_DB_PASSWORD']
+TEST_DB_HOST      = os.environ['TEST_DB_HOST']
+TEST_DB_NAME      = os.environ['TEST_DB_NAME']
+TEST_DB_URL       = 'mysql://{}:{}@{}/{}?charset=utf8mb4'.format(
+  TEST_DB_USERNAME,
+  TEST_DB_PASSWORD,
+  TEST_DB_HOST,
+  TEST_DB_NAME
+)
+
+# Analog of podcast database for testing purposes
+TEST_PODCAST_DB_USERNAME = os.environ['TEST_PODCAST_DB_USERNAME']
+TEST_PODCAST_DB_PASSWORD = os.environ['TEST_PODCAST_DB_PASSWORD']
+TEST_PODCAST_DB_HOST     = os.environ['TEST_PODCAST_DB_HOST']
+TEST_PODCAST_DB_NAME     = os.environ['TEST_PODCAST_DB_NAME']
+TEST_PODCAST_DB_URL      = 'mysql://{}:{}@{}/{}?charset=utf8mb4'.format(
+  TEST_PODCAST_DB_USERNAME,
+  TEST_PODCAST_DB_PASSWORD,
+  TEST_PODCAST_DB_HOST,
+  TEST_PODCAST_DB_NAME
+)
+
 class Config(object):
   DEBUG = False
   TESTING = False
@@ -55,3 +79,7 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(Config):
   TESTING = True
+  SQLALCHEMY_BINDS = {
+    'db': TEST_DB_URL,
+    'podcast_db': TEST_PODCAST_DB_URL
+  }

--- a/py/src/scripts/load_data.py
+++ b/py/src/scripts/load_data.py
@@ -2,10 +2,13 @@ import datetime
 import json
 import os
 import sys
+from script_utils import * # pylint: disable=W0403
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from app.pcasts.models._all import * # pylint: disable=C0413
-from app.pcasts.utils.db_utils import * # pylint: disable=C0413
+set_app_settings()
+
+from app.pcasts.models._all import * # pylint: disable=C0413,C0411
+from app.pcasts.utils.db_utils import * # pylint: disable=C0413,C0411
 
 def get_json_file_names():
   files = []

--- a/py/src/scripts/script_utils.py
+++ b/py/src/scripts/script_utils.py
@@ -1,0 +1,13 @@
+import sys
+import os
+
+def set_app_settings():
+  if len(sys.argv) > 1:
+    if sys.argv[1] == 'test':
+      os.environ['APP_SETTINGS'] = 'config.TestingConfig'
+    elif sys.argv[1] == 'dev':
+      os.environ['APP_SETTINGS'] = 'config.DevelopmentConfig'
+    else:
+      raise Exception("Invalid app setting argument")
+  else:
+    raise Exception("App setting required")

--- a/py/src/scripts/setup_db.py
+++ b/py/src/scripts/setup_db.py
@@ -1,0 +1,32 @@
+import sys
+import os
+import shutil
+from script_utils import * # pylint: disable=W0403
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+set_app_settings()
+
+from app import app # pylint: disable=C0413
+
+def setup_dbs():
+  print 'Setting up databases...'
+  os.chdir('..')
+  os.system('python manage.py db init --multidb')
+  os.system('python manage.py db migrate')
+  os.system('python manage.py db upgrade')
+  os.chdir('scripts')
+  print 'Finished setting up databases...'
+
+def delete_migrations():
+  try:
+    os.chdir('..')
+    shutil.rmtree('migrations')
+    os.chdir('scripts')
+    print 'Migrations folder deleted...'
+  except OSError:
+    os.chdir('scripts')
+    print 'No migrations folder to delete...'
+
+if __name__ == '__main__':
+  delete_migrations()
+  setup_dbs()

--- a/py/src/scripts/setup_db.py
+++ b/py/src/scripts/setup_db.py
@@ -21,6 +21,12 @@ def delete_migrations():
   try:
     os.chdir('..')
     shutil.rmtree('migrations')
+    for db in ['DB', 'PODCAST_DB', 'TEST_DB', 'TEST_PODCAST_DB']:
+      os.system('mysql --user={} --password={} {} '
+                .format(os.environ['{}_USERNAME'.format(db)],
+                        os.environ['{}_PASSWORD'.format(db)],
+                        os.environ['{}_NAME'.format(db)])
+                + '-e "drop table alembic_version"')
     os.chdir('scripts')
     print 'Migrations folder deleted...'
   except OSError:

--- a/py/tests/loading_utils.py
+++ b/py/tests/loading_utils.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+src_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + '/src'
+sys.path.append(src_path)
+
+from app import app # pylint: disable=C0413
+from app.pcasts.models._all import * # pylint: disable=C0413
+from app.pcasts.utils.db_utils import * # pylint: disable=C0413
+
+def load_users():
+  default_users = [
+      User(
+          google_id='default_google_id1',
+          email='default_email1',
+          first_name='default_first_name1',
+          last_name='default_last_name1',
+          image_url='',
+          followers_count=0,
+          followings_count=0,
+      ),
+      User(
+          google_id='default_google_id2',
+          email='default_email2',
+          first_name='default_first_name2',
+          last_name='default_last_name2',
+          image_url='',
+          followers_count=0,
+          followings_count=0,
+      )
+  ]
+
+  User.query.delete()
+  db_session_commit()
+  commit_models(default_users)

--- a/py/tests/test_case.py
+++ b/py/tests/test_case.py
@@ -1,0 +1,11 @@
+import unittest
+import os
+import sys
+
+from tests.loading_utils import * # pylint: disable=C0413
+
+class TestCase(unittest.TestCase):
+
+  def setUp(self):
+    self.app = app.test_client()
+    load_users()

--- a/py/tests/test_case.py
+++ b/py/tests/test_case.py
@@ -1,0 +1,11 @@
+import unittest
+import os
+import sys
+
+from tests.loading_utils import *
+
+class TestCase(unittest.TestCase):
+
+  def setUp(self):
+    self.app = app.test_client()
+    load_users()

--- a/py/tests/test_subscriptions.py
+++ b/py/tests/test_subscriptions.py
@@ -1,0 +1,15 @@
+from tests.test_case import *
+from app.pcasts.dao import subscriptions_dao # pylint: disable=C0413
+
+class SubscriptionsTestCase(TestCase):
+
+  def setUp(self):
+    super(SubscriptionsTestCase, self).setUp()
+    Subscription.query.delete() # delete all existing subscriptions
+    db_session_commit()
+
+  def test_get_subscriptions(self):
+    assert not subscriptions_dao.get_user_subscriptions(1)
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Ok to test all of this stuff out you guys have to do a few things, most of this stuff is in the README
1. Change the .env file that you guys already have to include the env variables for the test databases
2. Add the .env file in the `/tests` directory
3. Create the test databases in MySQL 
4. Run the `python setup_db.py dev` and `python setup_db.py test` commands. In MySQL, check the 4 databases to make sure the tables are there
5. either `pip install nose` or upgrade all the requirements, whatever you like
6. in the /tests directory, run `nosetests`. Then in MySQL, check the `test_pcasts_db_dev` database's users table. There should be two rows. Swap to the `pcasts_db_dev` database, and check the users there. It should be empty; this means that the dev and testing environments are being separated correctly, since the unit tests were responsible for generating the two default users

So as I explained before, we are gonna have 2 analog databases for testing purposes since I didn't find anything about in-memory MySQL, on sqlite which I tried but conflicted with the schema. Which environment we are using will be determined by the environment variables, since in `TestingConfig` I overrode the `SQLALCHEMY_BINDS` with the testing dbs. Because its kinda annoying to set these up, I just wrote `setup_db.py` to facilitate the process

For now the subscriptions test case is obviously not comprehensive, I just wanted something there to run to make sure everything is working. 