### PR TITLE
last updated field for a series

### DIFF
--- a/src/app/pcasts/dao/episodes_dao.py
+++ b/src/app/pcasts/dao/episodes_dao.py
@@ -1,6 +1,8 @@
 from . import *
 
 def get_episodes(episode_ids, user_id):
+  if not episode_ids:
+    return []
   episodes = Episode.query.filter(Episode.id.in_(episode_ids)).all()
   for e in episodes:
     e.is_recommended = is_recommended_by_user(e.id, user_id)

--- a/src/app/pcasts/dao/series_dao.py
+++ b/src/app/pcasts/dao/series_dao.py
@@ -1,3 +1,4 @@
+from sqlalchemy.sql.expression import func
 from app.pcasts.dao import episodes_dao
 from . import *
 
@@ -10,12 +11,18 @@ def get_series(series_id, user_id):
   return series
 
 def get_multiple_series(series_ids, user_id):
-  series = Series.query.filter(Series.id.in_(series_ids)).all()
-  for s in series:
+  if not series_ids:
+    return []
+  series = Series.query.filter(Series.id.in_(series_ids)) \
+    .order_by(Series.id.asc()).all()
+  last_updated_result = Episode.query \
+    .with_entities(Episode.series_id, func.max(Episode.created_at)) \
+    .filter(Episode.series_id.in_(series_ids)) \
+    .group_by(Episode.series_id) \
+    .order_by(Episode.series_id.asc()).all()
+  for s, (_, last_updated) in zip(series, last_updated_result):
     s.is_subscribed = is_subscribed_by_user(s.id, user_id)
-    most_recent_episode = Episode.query.filter(Episode.series_id == s.id) \
-      .order_by(Episode.created_at.desc()).limit(1).first()
-    s.last_updated = most_recent_episode.created_at
+    s.last_updated = last_updated
   return series
 
 def clear_all_subscriber_counts():

--- a/src/app/pcasts/dao/series_dao.py
+++ b/src/app/pcasts/dao/series_dao.py
@@ -1,14 +1,21 @@
+from app.pcasts.dao import episodes_dao
 from . import *
 
 def get_series(series_id, user_id):
   series = Series.query.filter(Series.id == series_id).first()
   series.is_subscribed = is_subscribed_by_user(series_id, user_id)
+  most_recent_episode = Episode.query.filter(Episode.series_id == series_id) \
+    .order_by(Episode.created_at.desc()).limit(1).first()
+  series.last_updated = most_recent_episode.created_at
   return series
 
 def get_multiple_series(series_ids, user_id):
   series = Series.query.filter(Series.id.in_(series_ids)).all()
   for s in series:
     s.is_subscribed = is_subscribed_by_user(s.id, user_id)
+    most_recent_episode = Episode.query.filter(Episode.series_id == s.id) \
+      .order_by(Episode.created_at.desc()).limit(1).first()
+    s.last_updated = most_recent_episode.created_at
   return series
 
 def clear_all_subscriber_counts():

--- a/src/app/pcasts/models/_all.py
+++ b/src/app/pcasts/models/_all.py
@@ -1,4 +1,5 @@
 from marshmallow_sqlalchemy import ModelSchema
+from marshmallow import fields
 from app.pcasts.models.user import *
 from app.pcasts.models.series import *
 from app.pcasts.models.episode import *
@@ -26,6 +27,7 @@ class SubscriptionSchema(ModelSchema):
 class SeriesSchema(ModelSchema):
   class Meta(ModelSchema.Meta):
     model = Series
+  last_updated = fields.DateTime()
 
 class EpisodeSchema(ModelSchema):
   class Meta(ModelSchema.Meta):

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-python ../venv/bin/nosetests --nocapture
+if [ $# -eq 0 ]
+then
+  python ../venv/bin/nosetests --nocapture
+else
+  python ../venv/bin/nosetests $1 --nocapture
+fi

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -62,6 +62,7 @@ class SubscriptionsTestCase(TestCase):
                             format(series_id2, 0, 1))
     data = json.loads(response.data)
     self.assertEquals(len(data['data']['subscriptions']), 1)
+    self.assertTrue(data['data']['subscriptions'][0]['series']['last_updated'])
     self.assertEquals(
         data['data']['subscriptions'][0]['series_id'], int(series_id2)
     )


### PR DESCRIPTION
The client model for a series (and a few views) use the date that a series last released an episode. We discussed this a few weeks ago, but I really don't remember why we decided not to implement it. Instead of changing those views, I just quickly implemented it.

I'm not sure how to test this functionality, since we would make sure it's correct using the same SQL query that I'm using in the DAO. All previous tests still pass with this update.