### PR TITLE
Fix is_bookmarked bug with new episodes of subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ To run all unit tests, from the `/tests` directory, run:
 ````
 ./test.sh
 ````
+
+To run a single test, from the `/tests` directory, run:
+````
+./test.sh test_file_name.py
+````

--- a/src/app/pcasts/dao/episodes_dao.py
+++ b/src/app/pcasts/dao/episodes_dao.py
@@ -27,6 +27,18 @@ def get_episodes_by_series(series_id, offset, max_search):
       .offset(offset).limit(max_search).all()
   return episodes
 
+def get_episodes_maxtime(user_id, series_ids, maxdatetime, page_size):
+  episodes = Episode.query \
+    .filter(Episode.series_id.in_(series_ids),
+            Episode.created_at <= maxdatetime) \
+    .order_by(Episode.created_at.desc()) \
+    .limit(page_size) \
+    .all()
+  for e in episodes:
+    e.is_recommended = is_recommended_by_user(e.id, user_id)
+    e.is_bookmarked = is_bookmarked_by_user(e.id, user_id)
+  return episodes
+
 def clear_all_recommendations_counts():
   episodes = Episode.query.filter(Episode.recommendations_count > 0).all()
   for e in episodes:

--- a/src/app/pcasts/dao/subscriptions_dao.py
+++ b/src/app/pcasts/dao/subscriptions_dao.py
@@ -1,5 +1,5 @@
 import datetime
-from app.pcasts.dao import series_dao
+from app.pcasts.dao import series_dao, episodes_dao
 from . import *
 
 def get_user_subscriptions(user_id):
@@ -59,9 +59,9 @@ def get_new_subscribed_episodes(user_id, maxtime, page_size):
   subscriptions = get_user_subscriptions(user_id)
   series_ids = [s.series_id for s in subscriptions]
   maxdatetime = datetime.datetime.fromtimestamp(int(maxtime))
-  return Episode.query \
-    .filter(Episode.series_id.in_(series_ids),
-            Episode.created_at <= maxdatetime) \
-    .order_by(Episode.created_at.desc()) \
-    .limit(page_size) \
-    .all()
+  return episodes_dao.get_episodes_maxtime(
+      user_id,
+      series_ids,
+      maxdatetime,
+      page_size
+  )


### PR DESCRIPTION
<img width="795" alt="screen shot 2017-10-11 at 8 07 06 pm" src="https://user-images.githubusercontent.com/11747956/31473089-5afaf14c-aec0-11e7-83f8-6a40ed500603.png">

Because there was a raw Episode query from `subscriptions_dao`, the `is_bookmarked` and `is_recommended` were not being attached

#118 