### PR TITLE
Jesse/get recommendations bug

### DIFF
--- a/src/app/pcasts/controllers/get_user_recommendations_controller.py
+++ b/src/app/pcasts/controllers/get_user_recommendations_controller.py
@@ -10,8 +10,12 @@ class GetUserRecommendationsController(AppDevController):
 
   @authorize
   def content(self, **kwargs):
-    user_id = request.view_args['user_id']
-    recommendations = recommendations_dao.get_user_recommendations(user_id)
+    caller_user_id = kwargs.get('user').id
+    requested_user_id = request.view_args['user_id']
+    recommendations = recommendations_dao.get_user_recommendations(
+        caller_user_id,
+        requested_user_id
+    )
 
     return {'recommendations': \
       [recommendation_schema.dump(r).data for r in recommendations]}

--- a/src/app/pcasts/dao/recommendations_dao.py
+++ b/src/app/pcasts/dao/recommendations_dao.py
@@ -23,12 +23,14 @@ def delete_recommendation(episode_id, user):
   else:
     raise Exception('Specified recommendation does not exist')
 
-def get_user_recommendations(user_id):
+def get_user_recommendations(caller_user_id, requested_user_id):
   recommendations = (
-      Recommendation.query.filter(Recommendation.user_id == user_id).all()
+      Recommendation.query.\
+      filter(Recommendation.user_id == requested_user_id).\
+      all()
   )
   episodes = episodes_dao.get_episodes([r.episode_id for r in recommendations],
-                                       user_id)
+                                       caller_user_id)
   for r, e in zip(recommendations, episodes):
     r.episode = e
   return recommendations


### PR DESCRIPTION
Fixes situation where user A hits `get_user_recommendations` endpoint for user B, and the episodes that are returned are marked with booleans `is_recommended` and `is_bookmarked` in the context of user B, instead of user A

<img width="507" alt="screen shot 2017-10-15 at 5 43 17 pm" src="https://user-images.githubusercontent.com/11747956/31589492-5c163790-b1d0-11e7-803a-216337f4b800.png">
