### PR TITLE
Attach is_following fields to the nested users in a following object

### DIFF
--- a/src/app/pcasts/controllers/get_user_followers_controller.py
+++ b/src/app/pcasts/controllers/get_user_followers_controller.py
@@ -10,7 +10,10 @@ class GetUserFollowersController(AppDevController):
 
   @authorize
   def content(self, **kwargs):
+    my_id = kwargs.get('user').id
     user_id = request.view_args['user_id']
-    followings = followings_dao.get_followers(user_id)
+    followers = followings_dao.get_followers(user_id)
+    followers_json = [following_schema.dump(f).data for f in followers]
+    followings_dao.attach_is_following_to_json(my_id, followers_json)
 
-    return {'followers': [following_schema.dump(f).data for f in followings]}
+    return {'followers': followers_json}

--- a/src/app/pcasts/controllers/get_user_followings_controller.py
+++ b/src/app/pcasts/controllers/get_user_followings_controller.py
@@ -10,7 +10,10 @@ class GetUserFollowingsController(AppDevController):
 
   @authorize
   def content(self, **kwargs):
+    my_id = kwargs.get('user').id
     user_id = request.view_args['user_id']
     followings = followings_dao.get_followings(user_id)
+    followings_json = [following_schema.dump(f).data for f in followings]
+    followings_dao.attach_is_following_to_json(my_id, followings_json)
 
-    return {'followings': [following_schema.dump(f).data for f in followings]}
+    return {'followings': followings_json}

--- a/src/app/pcasts/dao/followings_dao.py
+++ b/src/app/pcasts/dao/followings_dao.py
@@ -78,3 +78,10 @@ def get_following_subscriptions(user_id, maxtime, page_size):
   for sub, ser in zip(subscriptions, series):
     sub.series = ser
   return subscriptions
+
+def attach_is_following_to_json(my_id, followings_json):
+  for json in followings_json:
+    json['follower'][unicode('is_following', "utf-8")] = users_dao.\
+        is_following_user(my_id, json['follower']['id'])
+    json['followed'][unicode('is_following', "utf-8")] = users_dao.\
+        is_following_user(my_id, json['followed']['id'])

--- a/src/app/pcasts/dao/users_dao.py
+++ b/src/app/pcasts/dao/users_dao.py
@@ -55,11 +55,11 @@ def get_user_by_google_id(google_id):
     return optional_user
 
 def is_following_user(my_id, their_id):
-    optional_following = Following.query \
-      .filter(Following.follower_id == my_id,
-              Following.followed_id == their_id) \
-      .first()
-    return optional_following is not None
+  optional_following = Following.query \
+    .filter(Following.follower_id == my_id,
+            Following.followed_id == their_id) \
+    .first()
+  return optional_following is not None
 
 def search_users(search_name, offset, max_search):
   possible_users = User.query.filter \

--- a/tests/test_followings.py
+++ b/tests/test_followings.py
@@ -59,6 +59,13 @@ class FollowingsTestCase(TestCase):
         data['data']['followings'][0]['followed']['id'],
         test_user_id2
     )
+    # From the point of view of user1, are we following user1 or user2
+    self.assertFalse(
+        data['data']['followings'][0]['follower']['is_following']
+    )
+    self.assertTrue(
+        data['data']['followings'][0]['followed']['is_following']
+    )
 
     response = self.app.get('api/v1/followers/show/{}/'.format(test_user_id1))
     data = json.loads(response.data)
@@ -70,6 +77,7 @@ class FollowingsTestCase(TestCase):
 
     response = self.app.get('api/v1/followers/show/{}/'.format(test_user_id2))
     data = json.loads(response.data)
+
     self.assertEquals(len(data['data']['followers']), 1)
     self.assertEquals(
         data['data']['followers'][0]['follower']['id'],
@@ -78,6 +86,13 @@ class FollowingsTestCase(TestCase):
     self.assertEquals(
         data['data']['followers'][0]['followed']['id'],
         test_user_id2
+    )
+    # From the point of view of user1 are we following user1 and user2
+    self.assertFalse(
+        data['data']['followers'][0]['follower']['is_following']
+    )
+    self.assertTrue(
+        data['data']['followers'][0]['followed']['is_following']
     )
 
   def test_delete_followings(self):


### PR DESCRIPTION
<img width="799" alt="screen shot 2017-10-26 at 5 55 09 pm" src="https://user-images.githubusercontent.com/11747956/32079033-1fc283f2-ba77-11e7-840c-ccb41e97b853.png">

#133 

We are forced to add the fields after the json has been constructed, because we are relying on Marshmallow/SQLAlchemy to serialize the json based on the schema (and thus its responsible for constructing the nested user object, we don't have access to it until after the serialization)