### PR TITLE
iTunes Error Handling + Increased Test Coverage

### DIFF
--- a/src/app/pcasts/dao/series_dao.py
+++ b/src/app/pcasts/dao/series_dao.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime as dt
 from sqlalchemy.sql.expression import func
 from app.pcasts.dao import episodes_dao
 from . import *
@@ -17,11 +17,13 @@ def store_series_and_episodes_from_feed(feed):
   )
   models_to_commit = [new_series]
   for episode_dict in feed.get('episodes'):
+    pub_date = None if episode_dict.get('pub_date') is None else \
+      dt.fromtimestamp(episode_dict.get('pub_date'))
     ep = Episode(
         title=episode_dict.get('title'),
         author=episode_dict.get('author'),
         summary=episode_dict.get('summary'),
-        pub_date=datetime.datetime.fromtimestamp(episode_dict.get('pub_date')),
+        pub_date=pub_date,
         duration=episode_dict.get('duration'),
         audio_url=episode_dict.get('audio_url'),
         tags=episode_dict.get('tags'),

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ $# -eq 0 ]
 then
-  python ../venv/bin/nosetests --nocapture -s
+  python ../venv/bin/nosetests --nocapture
 else
-  python ../venv/bin/nosetests $1 --nocapture -s
+  python ../venv/bin/nosetests $1 --nocapture
 fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ $# -eq 0 ]
 then
-  python ../venv/bin/nosetests --nocapture
+  python ../venv/bin/nosetests --nocapture -s
 else
-  python ../venv/bin/nosetests $1 --nocapture
+  python ../venv/bin/nosetests $1 --nocapture -s
 fi

--- a/tests/test_itunes.py
+++ b/tests/test_itunes.py
@@ -4,13 +4,27 @@ from app.pcasts.dao import series_dao
 
 class iTunesTestCase(TestCase):
 
-  def test_search_itunes(self):
-    response = self.app.post('api/v1/search/itunes/programming/')
+  def _clean_up(self, data):
+    new_series_ids = data.get('data').get('new_series_ids')
+    for new_series_id in new_series_ids:
+      series_dao.remove_series(new_series_id)
+
+  def _itunes_smoke_test(self, query):
+    response = self.app.post('api/v1/search/itunes/{}/'.format(query))
     data = json.loads(response.data)
     # There should definitely be non-zero results
     series = data.get('data', dict()).get('series', [])
     self.assertTrue(len(series) > 0)
-    # Clean up
-    new_series_ids = data.get('data').get('new_series_ids')
-    for new_series_id in new_series_ids:
-      series_dao.remove_series(new_series_id)
+    self._clean_up(data)
+
+  def test_search_itunes_1(self):
+    self._itunes_smoke_test('programming')
+
+  def test_search_itunes_2(self):
+    self._itunes_smoke_test('a%20piece')
+
+  def test_search_itunes_3(self):
+    self._itunes_smoke_test('The%20Ben%20and')
+
+  def test_search_itunes_4(self):
+    self._itunes_smoke_test('Some')


### PR DESCRIPTION
Addresses issues presented in Slack conversation (queries such as "a piece", "Some" etc. that were previously throwing errors no longer throw errors) by increasing error handling.  Also addresses queries for the podcast presented in #145, which no longer throw errors of any sort.  