### PR TITLE
Avoid race conditions, be careful with casting, still cant replicate

### DIFF
--- a/src/app/pcasts/dao/followings_dao.py
+++ b/src/app/pcasts/dao/followings_dao.py
@@ -16,14 +16,16 @@ def get_followers(user_id):
   return followers
 
 def create_following(follower_id, followed_id):
-  if int(follower_id) != int(followed_id):
+  follower_id = int(follower_id)
+  followed_id = int(followed_id)
+  if follower_id != followed_id:
     users = users_dao.get_users_by_id(follower_id, [follower_id, followed_id])
     if len(users) == 2:
       following = Following(follower_id=follower_id, followed_id=followed_id)
       follower = users[0] if users[0].id == follower_id else users[1]
       followed = users[0] if users[0].id == followed_id else users[1]
-      follower.followings_count += 1
-      followed.followers_count += 1
+      follower.followings_count = follower.followings_count + 1
+      followed.followers_count = followed.followers_count + 1
       return db_utils.commit_model(following)
     else:
       raise Exception("Improper follower_id and/or followed_id")
@@ -31,6 +33,8 @@ def create_following(follower_id, followed_id):
     raise Exception("follower_id cannot equal followed_id")
 
 def delete_following(follower_id, followed_id):
+  follower_id = int(follower_id)
+  followed_id = int(followed_id)
   maybe_following = Following.query \
     .filter(Following.follower_id == follower_id,
             Following.followed_id == followed_id) \
@@ -40,8 +44,9 @@ def delete_following(follower_id, followed_id):
     users = users_dao.get_users_by_id(follower_id, [follower_id, followed_id])
     follower = users[0] if users[0].id == follower_id else users[1]
     followed = users[0] if users[0].id == followed_id else users[1]
-    follower.followings_count -= 1
-    followed.followers_count -= 1
+    follower.followings_count = follower.followings_count - 1
+    followed.followers_count = followed.followers_count - 1
+
     db_utils.delete_model(maybe_following)
   else:
     raise Exception("Specified following does not exist")

--- a/src/app/pcasts/dao/users_dao.py
+++ b/src/app/pcasts/dao/users_dao.py
@@ -56,7 +56,8 @@ def get_user_by_valid_session(session_token):
 def get_user_by_id(my_id, their_id):
   users = get_users_by_id(my_id, [their_id])
   if not users:
-    raise Exception('User with user_id: {} does not exist'.format(str(user_id)))
+    raise Exception('User with user_id: {} does not exist'.\
+                    format(str(their_id)))
   else:
     return users[0]
 

--- a/src/app/pcasts/utils/authorize.py
+++ b/src/app/pcasts/utils/authorize.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 from functools import wraps
+from app import app
 from app import constants
 from app.pcasts.dao import users_dao
 from flask import request, jsonify
@@ -8,7 +9,7 @@ from flask import request, jsonify
 def authorize(f):
   @wraps(f)
   def authorization_decorator(*args, **kwargs):
-    if os.environ['APP_SETTINGS'] == constants.TEST_APP_SETTING:
+    if app.config['TESTING']:
       test_user = users_dao.\
         get_user_by_google_id(constants.TEST_USER_GOOGLE_ID1)
       if test_user:

--- a/tests/test_followings.py
+++ b/tests/test_followings.py
@@ -49,6 +49,16 @@ class FollowingsTestCase(TestCase):
     self.assertEquals(int(user2.followers_count), 1)
     self.assertEquals(int(user2.followings_count), 0)
 
+    self.assertRaises(Exception, self.app.post(),
+                      'api/v1/followings/{}/'.format(1234))
+
+    user1 = users_dao.get_user_by_google_id(constants.TEST_USER_GOOGLE_ID1)
+    user2 = users_dao.get_user_by_google_id(constants.TEST_USER_GOOGLE_ID2)
+    self.assertEquals(int(user1.followers_count), 0)
+    self.assertEquals(int(user1.followings_count), 1)
+    self.assertEquals(int(user2.followers_count), 1)
+    self.assertEquals(int(user2.followings_count), 0)
+
     self.app.post('api/v1/followings/{}/'.format(test_user_id3))
     following = Following.query.\
         filter(Following.follower_id == test_user_id1).all()[1]
@@ -149,6 +159,26 @@ class FollowingsTestCase(TestCase):
     response = self.app.get('api/v1/followings/show/{}/'.format(test_user_id1))
     data = json.loads(response.data)
     self.assertEquals(len(data['data']['followings']), 1)
+    self.assertEquals(
+        data['data']['followings'][0]['follower']['followings_count'], 1
+    )
+    self.assertEquals(
+        data['data']['followings'][0]['follower']['followers_count'], 0
+    )
+    self.assertEquals(
+        data['data']['followings'][0]['followed']['followings_count'], 0
+    )
+    self.assertEquals(
+        data['data']['followings'][0]['followed']['followers_count'], 1
+    )
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id1))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id2))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
 
     response = self.app.get('api/v1/followers/show/{}/'.format(test_user_id1))
     data = json.loads(response.data)
@@ -157,6 +187,18 @@ class FollowingsTestCase(TestCase):
     response = self.app.get('api/v1/followers/show/{}/'.format(test_user_id2))
     data = json.loads(response.data)
     self.assertEquals(len(data['data']['followers']), 1)
+    self.assertEquals(
+        data['data']['followers'][0]['follower']['followings_count'], 1
+    )
+    self.assertEquals(
+        data['data']['followers'][0]['follower']['followers_count'], 0
+    )
+    self.assertEquals(
+        data['data']['followers'][0]['followed']['followings_count'], 0
+    )
+    self.assertEquals(
+        data['data']['followers'][0]['followed']['followers_count'], 1
+    )
 
     response = self.app.get('api/v1/followings/show/{}/'.format(test_user_id2))
     data = json.loads(response.data)
@@ -167,6 +209,27 @@ class FollowingsTestCase(TestCase):
     response = self.app.get('api/v1/followings/show/{}/'.format(test_user_id1))
     data = json.loads(response.data)
     self.assertEquals(len(data['data']['followings']), 1)
+    self.assertEquals(
+        data['data']['followings'][0]['follower']['followings_count'], 1
+    )
+    self.assertEquals(
+        data['data']['followings'][0]['follower']['followers_count'], 1
+    )
+    self.assertEquals(
+        data['data']['followings'][0]['followed']['followings_count'], 1
+    )
+    self.assertEquals(
+        data['data']['followings'][0]['followed']['followers_count'], 1
+    )
+    user_data = json.loads(user_response.data)
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id1))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id2))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
 
     response = self.app.get('api/v1/followers/show/{}/'.format(test_user_id1))
     data = json.loads(response.data)
@@ -181,7 +244,25 @@ class FollowingsTestCase(TestCase):
     self.assertEquals(len(data['data']['followings']), 1)
 
     self.app.delete('api/v1/followings/{}/'.format(test_user_id2))
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id1))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id2))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+
     followings_dao.delete_following(test_user_id2, test_user_id1)
+    user_data = json.loads(user_response.data)
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id1))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+    user_response = self.app.get('api/v1/users/{}/'.format(test_user_id2))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
 
     response = self.app.get('api/v1/followings/show/{}/'.format(test_user_id1))
     data = json.loads(response.data)
@@ -219,8 +300,28 @@ class FollowingsTestCase(TestCase):
     user3 = users_dao.\
         get_user_by_google_id(constants.TEST_USER_GOOGLE_ID3)
 
+    user_response = self.app.get('api/v1/users/{}/'.format(user1.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+    user_response = self.app.get('api/v1/users/{}/'.format(user2.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+    user_response = self.app.get('api/v1/users/{}/'.format(user3.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+
     followings_dao.create_following(user1.id, user2.id)
     followings_dao.create_following(user1.id, user3.id)
+
+    user1 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID1)
+    user2 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID2)
+    user3 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID3)
 
     self.assertEquals(int(user1.followings_count), 2)
     self.assertEquals(int(user2.followings_count), 0)
@@ -230,8 +331,28 @@ class FollowingsTestCase(TestCase):
     self.assertEquals(int(user2.followers_count), 1)
     self.assertEquals(int(user3.followers_count), 1)
 
+    user_response = self.app.get('api/v1/users/{}/'.format(user1.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 2)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+    user_response = self.app.get('api/v1/users/{}/'.format(user2.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
+    user_response = self.app.get('api/v1/users/{}/'.format(user3.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
+
     followings_dao.create_following(user2.id, user1.id)
     followings_dao.create_following(user3.id, user1.id)
+
+    user1 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID1)
+    user2 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID2)
+    user3 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID3)
 
     self.assertEquals(int(user1.followings_count), 2)
     self.assertEquals(int(user2.followings_count), 1)
@@ -241,8 +362,28 @@ class FollowingsTestCase(TestCase):
     self.assertEquals(int(user2.followers_count), 1)
     self.assertEquals(int(user3.followers_count), 1)
 
+    user_response = self.app.get('api/v1/users/{}/'.format(user1.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 2)
+    self.assertEquals(user_data['data']['user']['followers_count'], 2)
+    user_response = self.app.get('api/v1/users/{}/'.format(user2.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
+    user_response = self.app.get('api/v1/users/{}/'.format(user3.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
+
     followings_dao.delete_following(user1.id, user2.id)
     followings_dao.delete_following(user1.id, user3.id)
+
+    user1 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID1)
+    user2 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID2)
+    user3 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID3)
 
     self.assertEquals(int(user1.followings_count), 0)
     self.assertEquals(int(user2.followings_count), 1)
@@ -252,10 +393,30 @@ class FollowingsTestCase(TestCase):
     self.assertEquals(int(user2.followers_count), 0)
     self.assertEquals(int(user3.followers_count), 0)
 
+    user_response = self.app.get('api/v1/users/{}/'.format(user1.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 0)
+    self.assertEquals(user_data['data']['user']['followers_count'], 2)
+    user_response = self.app.get('api/v1/users/{}/'.format(user2.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+    user_response = self.app.get('api/v1/users/{}/'.format(user3.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+
     self.assertRaises(Exception, followings_dao.delete_following,
                       user1.id, user2.id)
     self.assertRaises(Exception, followings_dao.delete_following,
                       user1.id, user3.id)
+
+    user1 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID1)
+    user2 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID2)
+    user3 = users_dao.\
+        get_user_by_google_id(constants.TEST_USER_GOOGLE_ID3)
 
     self.assertEquals(int(user1.followings_count), 0)
     self.assertEquals(int(user2.followings_count), 1)
@@ -273,6 +434,22 @@ class FollowingsTestCase(TestCase):
     self.assertEquals(int(user1.followers_count), 2)
     self.assertEquals(int(user2.followers_count), 1)
     self.assertEquals(int(user3.followers_count), 0)
+
+    user_response = self.app.get('api/v1/users/{}/'.format(user1.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 2)
+    user_response = self.app.get('api/v1/users/{}/'.format(user2.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 1)
+    user_response = self.app.get('api/v1/users/{}/'.format(user3.id))
+    user_data = json.loads(user_response.data)
+    self.assertEquals(user_data['data']['user']['followings_count'], 1)
+    self.assertEquals(user_data['data']['user']['followers_count'], 0)
+
+    self.assertRaises(Exception,
+                      followings_dao.create_following, user1.id, 1234)
 
   def test_is_following(self):
     following = User.query \


### PR DESCRIPTION
Only thing that I could find is the casting inconsistency that Joe mentioned in Slack (didn't seem to make a difference wrt the tests), and race conditions where I read online that we shouldn't be doing `object.field += 1`.

My thoughts on possible reasons for the bug:
- I think there was a window where we deployed without my last attempt to fix the following bugs(with guaranteeing the rollback) so maybe the counts were already messed up before the fix. Kinda unlikely, since the rollback bug shouldn't happen that often
- Race conditions? seems pretty unlikely b/c we don't have that many ppl but its a possibility
- Some external factor - the tests are pretty comprehensive at this point and the counts are fine in them, so at this point the probability of some external factor being the cause (rather than the code) is high imo