### PR TITLE
LastUpdated Fix For Series + Other Random Search Fixes

### DIFF
--- a/src/app/pcasts/dao/episodes_dao.py
+++ b/src/app/pcasts/dao/episodes_dao.py
@@ -63,7 +63,7 @@ def search_episode(search_name, offset, max_search, user_id):
       tup[0] for tup in
       Episode.query.\
       with_entities(Episode.id).\
-      filter(Episode.title.like(search_name + '%')).\
+      filter(Episode.title.like('%' + search_name + '%')).\
       offset(offset).\
       limit(max_search).\
       all()

--- a/src/app/pcasts/dao/users_dao.py
+++ b/src/app/pcasts/dao/users_dao.py
@@ -84,7 +84,7 @@ def is_following_user(my_id, their_id):
 
 def search_users(search_name, offset, max_search, user_id):
   possible_users = User.query.filter \
-      (User.username.like(search_name+'%')) \
+      (User.username.like('%' + search_name + '%')) \
       .offset(offset).limit(max_search).all()
   for u in possible_users:
     u.is_following = is_following_user(user_id, u.id)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,12 +6,6 @@ from app import constants # pylint: disable=C0413
 
 class SearchTestCase(TestCase):
 
-  def setUp(self):
-    super(SearchTestCase, self).setUp()
-
-  def tearDown(self):
-    super(SearchTestCase, self).tearDown()
-
   def test_search_all(self):
     no_result_title = 'ABCDEFGHIJKL'
     search_results = self.app.get('api/v1/search/all/{}/?offset={}&max={}'\
@@ -21,26 +15,25 @@ class SearchTestCase(TestCase):
     self.assertEquals(0, len(no_result_data['data']['episodes']))
     self.assertEquals(0, len(no_result_data['data']['series']))
 
-    #Full query
+    # Full query
     some_result_title = 'te'
     search_results = self.app.get('api/v1/search/all/{}/?offset={}&max={}'\
         .format(some_result_title, 0, 1000))
     some_result_data = json.loads(search_results.data)
     self.assertEquals(3, len(some_result_data['data']['users']))
     self.assertFalse(some_result_data['data']['users'][0]['is_following'])
-    self.assertEquals(215, len(some_result_data['data']['episodes']))
-    self.assertEquals(6, len(some_result_data['data']['series']))
+    self.assertEquals(1000, len(some_result_data['data']['episodes']))
+    self.assertEquals(125, len(some_result_data['data']['series']))
 
-    #Partially Empty query
+    # Partially Empty query
     two_empty_result_title = 'tat'
     te_result = self.app.get('api/v1/search/all/{}/?offset={}&max={}'\
         .format(two_empty_result_title, 0, 1000))
     te_result = json.loads(te_result.data)
     self.assertEquals(0, len(te_result['data']['users']))
-    self.assertEquals(4, len(te_result['data']['episodes']))
-    self.assertEquals(0, len(te_result['data']['series']))
+    self.assertEquals(1000, len(te_result['data']['episodes']))
+    self.assertEquals(18, len(te_result['data']['series']))
 
-    ##offset
     some_result_title = 'te'
     offset_results = self.app.get('api/v1/search/all/{}/?offset={}&max={}'\
         .format(some_result_title, 1, 2))
@@ -58,7 +51,7 @@ class SearchTestCase(TestCase):
     self.assertEquals(normal_result_data['data']['series'][1]['title'], \
         offset_result_data['data']['series'][0]['title'])
 
-    ##Limit
+    # Limit
     some_result_title = 'te'
     search_results = self.app.get('api/v1/search/all/{}/?offset={}&max={}'\
         .format(some_result_title, 0, 3))
@@ -72,7 +65,7 @@ class SearchTestCase(TestCase):
     search_results = self.app.get('api/v1/search/episodes/{}/?offset={}&max={}'\
          .format(title, 0, 1000))
     result_data = json.loads(search_results.data)
-    self.assertEquals(1, len(result_data['data']['episodes']))
+    self.assertTrue(len(result_data['data']['episodes']) > 0)
     self.assertIsNotNone(result_data['data']['episodes'][0]['is_bookmarked'])
     self.assertIsNotNone(result_data['data']['episodes'][0]['is_recommended'])
 
@@ -83,26 +76,20 @@ class SearchTestCase(TestCase):
     no_result_data = json.loads(search_results.data)
     self.assertEquals(0, len(no_result_data['data']['episodes']))
 
-    one_result_title = 'Junk'
-    search_results = self.app.get('api/v1/search/episodes/{}/?offset={}&max={}'\
-         .format(one_result_title, 0, 1000))
-    one_result_data = json.loads(search_results.data)
-    self.assertEquals(1, len(one_result_data['data']['episodes']))
-
     many_result_title = 'Happy'
     search_results = self.app.get('api/v1/search/episodes/{}/?offset={}&max={}'\
          .format(many_result_title, 0, 1000))
     many_result_data = json.loads(search_results.data)
-    self.assertEquals(102, len(many_result_data['data']['episodes']))
+    self.assertEquals(260, len(many_result_data['data']['episodes']))
 
-    ##Test limit
+    # Test limit
     ten_result_title = 'newer'
     search_results = self.app.get('api/v1/search/episodes/{}/?offset={}&max={}'\
          .format(ten_result_title, 0, 4))
     ten_result_data = json.loads(search_results.data)
     self.assertEquals(4, len(ten_result_data['data']['episodes']))
 
-    ##Test offset
+    # Test offset
     offset_result_title = 'big d'
     normal_results = self.app.get('api/v1/search/episodes/{}/?offset={}&max={}'\
         .format(offset_result_title, 0, 10))
@@ -118,7 +105,7 @@ class SearchTestCase(TestCase):
     search_results = self.app.get('api/v1/search/series/{}/?offset={}&max={}'\
          .format(title, 0, 1000))
     result_data = json.loads(search_results.data)
-    self.assertEquals(1, len(result_data['data']['series']))
+    self.assertEquals(2, len(result_data['data']['series']))
     self.assertIsNotNone(result_data['data']['series'][0]['is_subscribed'])
 
   def test_search_series(self):
@@ -128,26 +115,20 @@ class SearchTestCase(TestCase):
     no_result_data = json.loads(search_results.data)
     self.assertEquals(0, len(no_result_data['data']['series']))
 
-    one_result_title = 'Jud'
-    search_results = self.app.get('api/v1/search/series/{}/?offset={}&max={}'\
-         .format(one_result_title, 0, 1000))
-    one_result_data = json.loads(search_results.data)
-    self.assertEquals(1, len(one_result_data['data']['series']))
-
-    many_result_title = 'a'
+    many_result_title = 'Jud'
     search_results = self.app.get('api/v1/search/series/{}/?offset={}&max={}'\
          .format(many_result_title, 0, 1000))
-    many_result_data = json.loads(search_results.data)
-    self.assertEquals(32, len(many_result_data['data']['series']))
+    many_result_title = json.loads(search_results.data)
+    self.assertEquals(2, len(many_result_title['data']['series']))
 
-    ##Test limit
+    # Test limit
     ten_result_title = 'a'
     search_results = self.app.get('api/v1/search/series/{}/?offset={}&max={}'\
          .format(ten_result_title, 0, 4))
     ten_result_data = json.loads(search_results.data)
     self.assertEquals(4, len(ten_result_data['data']['series']))
 
-    ##Test offset
+    # Test offset
     ten_result_title = 'Cl'
     offset_results = self.app.get('api/v1/search/series/{}/?offset={}&max={}'\
         .format(ten_result_title, 2, 10))
@@ -157,7 +138,6 @@ class SearchTestCase(TestCase):
     offset_result_data = json.loads(offset_results.data)
     self.assertEquals(offset_result_data['data']['series'][0]['title'], \
         normal_result_data['data']['series'][2]['title'])
-
 
   def test_search_user(self):
     no_result_username = 'ABCDEFGHIJKL'
@@ -179,14 +159,12 @@ class SearchTestCase(TestCase):
     many_result_data = json.loads(search_results.data)
     self.assertEquals(3, len(many_result_data['data']['users']))
 
-    ##Test limit
     two_result_username = 'temp-google-default_google_id'
     search_results = self.app.get('api/v1/search/users/{}/?offset={}&max={}'\
          .format(two_result_username, 0, 1))
     ten_result_data = json.loads(search_results.data)
     self.assertEquals(1, len(ten_result_data['data']['users']))
 
-    ##Test offset
     two_result_username = 'temp-google-default_google_id'
     normal_results = self.app.get('api/v1/search/users/{}/?offset={}&max={}'\
         .format(two_result_username, 0, 10))

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -34,3 +34,19 @@ class SeriesTestCase(TestCase):
       self.app.get('api/v1/discover/series/?offset={}&max={}'.format(0, 2))
     series_results = json.loads(response.data)['data']['series']
     self.assertEquals(int(series_id1), series_results[0]['id'])
+
+  def test_last_updated(self):
+    # Single
+    series_id = '1211520413'
+    response = self.app.get('api/v1/series/{}/'.format(series_id))
+    result = json.loads(response.data)['data']['series']
+    self.assertEqual(result['last_updated'], '2017-03-06T19:09:31+00:00')
+
+    # Multiple
+    search_endpoint = \
+      'api/v1/search/series/Laugh%20with%20Kirill%20&%20Kevin/?offset=0&max=1'
+    response = self.app.get(search_endpoint)
+    result = json.loads(response.data)['data']['series']
+    self.assertEqual(1, len(result))
+    single_result = result[0]
+    self.assertEqual(single_result['last_updated'], '2017-03-06T19:09:31+00:00')


### PR DESCRIPTION
`last_updated` fix for `series`, and quick fixes to search (`%` should be on either ends of the query string for maximum matches on a partial query).  