### PR TITLE
Hacky Fix to Feed (pub_date vs created_at for new Episodes published)

### DIFF
--- a/src/app/pcasts/controllers/get_feed_controller.py
+++ b/src/app/pcasts/controllers/get_feed_controller.py
@@ -33,11 +33,17 @@ class GetFeedController(AppDevController):
     new_subscribed_episodes = \
       subscriptions_dao.get_new_subscribed_episodes(user.id, maxtime, page_size)
 
+    # TODO - huge hack, fix later
+    augmented_episodes = []
+    for e in new_subscribed_episodes:
+      e.created_at = e.pub_date
+      augmented_episodes.append(e)
+
     feed = self.merge_sorted_feed_sources(
         [
             following_recommendations,
             following_subscriptions,
-            new_subscribed_episodes
+            augmented_episodes
         ],
         [
             FeedContexts.FOLLOWING_RECOMMENDATION,


### PR DESCRIPTION
See title - this fixes the sorting of episodes on the feed.  