### PR TITLE
Have pylint ignore C0413 (imports should be placed at top of module)

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -15,7 +15,7 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = True
 db = SQLAlchemy(app)
 
 # Import + Register Blueprints
-from app.pcasts import pcasts as pcasts # pylint: disable=C0413
+from app.pcasts import pcasts as pcasts
 app.register_blueprint(pcasts)
 
 # HTTP error handling

--- a/src/app/pcasts/__init__.py
+++ b/src/app/pcasts/__init__.py
@@ -5,39 +5,39 @@ from app import *
 pcasts = Blueprint('pcasts', __name__, url_prefix='/api/v1')
 
 # Import all models
-from app.pcasts.models._all import * # pylint: disable=C0413
+from app.pcasts.models._all import *
 
 # Import all controllers
-from app.pcasts.controllers.google_sign_in_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_me_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.series_subscriptions_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_user_subscriptions_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.create_delete_bookmark_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_bookmarks_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_create_delete_recommendation_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_user_recommendations_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.create_delete_following_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_user_followers_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_user_followings_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.delete_listening_history_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.listening_history_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.clear_listening_history_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_feed_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.update_session_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.sign_out_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.search_episode_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.search_series_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.search_users_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.search_all_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_episodes_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.series_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.get_user_by_id_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.update_username_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.discover_series_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.discover_episodes_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.facebook_sign_in_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.merge_account_controller import * # pylint: disable=C0413
-from app.pcasts.controllers.search_itunes_controller import * # pylint: disable=C0413
+from app.pcasts.controllers.google_sign_in_controller import *
+from app.pcasts.controllers.get_me_controller import *
+from app.pcasts.controllers.series_subscriptions_controller import *
+from app.pcasts.controllers.get_user_subscriptions_controller import *
+from app.pcasts.controllers.create_delete_bookmark_controller import *
+from app.pcasts.controllers.get_bookmarks_controller import *
+from app.pcasts.controllers.get_create_delete_recommendation_controller import *
+from app.pcasts.controllers.get_user_recommendations_controller import *
+from app.pcasts.controllers.create_delete_following_controller import *
+from app.pcasts.controllers.get_user_followers_controller import *
+from app.pcasts.controllers.get_user_followings_controller import *
+from app.pcasts.controllers.delete_listening_history_controller import *
+from app.pcasts.controllers.listening_history_controller import *
+from app.pcasts.controllers.clear_listening_history_controller import *
+from app.pcasts.controllers.get_feed_controller import *
+from app.pcasts.controllers.update_session_controller import *
+from app.pcasts.controllers.sign_out_controller import *
+from app.pcasts.controllers.search_episode_controller import *
+from app.pcasts.controllers.search_series_controller import *
+from app.pcasts.controllers.search_users_controller import *
+from app.pcasts.controllers.search_all_controller import *
+from app.pcasts.controllers.get_episodes_controller import *
+from app.pcasts.controllers.series_controller import *
+from app.pcasts.controllers.get_user_by_id_controller import *
+from app.pcasts.controllers.update_username_controller import *
+from app.pcasts.controllers.discover_series_controller import *
+from app.pcasts.controllers.discover_episodes_controller import *
+from app.pcasts.controllers.facebook_sign_in_controller import *
+from app.pcasts.controllers.merge_account_controller import *
+from app.pcasts.controllers.search_itunes_controller import *
 
 controllers = [
     GoogleSignInController(),

--- a/src/app/pcasts/models/user.py
+++ b/src/app/pcasts/models/user.py
@@ -1,5 +1,5 @@
-from . import *
 from sqlalchemy.orm import validates
+from . import *
 
 class User(Base):
   __tablename__ = 'users'

--- a/src/scripts/load_data.py
+++ b/src/scripts/load_data.py
@@ -7,8 +7,8 @@ from script_utils import * # pylint: disable=W0403
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 set_app_settings()
 
-from app.pcasts.models._all import * # pylint: disable=C0413,C0411
-from app.pcasts.utils.db_utils import * # pylint: disable=C0413,C0411
+from app.pcasts.models._all import *
+from app.pcasts.utils.db_utils import *
 
 def get_json_file_names():
   files = []

--- a/src/scripts/setup_db.py
+++ b/src/scripts/setup_db.py
@@ -6,7 +6,7 @@ from script_utils import * # pylint: disable=W0403
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 set_app_settings()
 
-from app import app # pylint: disable=C0413
+from app import app
 
 def setup_dbs():
   print 'Setting up databases...'

--- a/tests/api_utils.py
+++ b/tests/api_utils.py
@@ -3,8 +3,8 @@ import sys
 import json
 import config
 import requests
-from app import app # pylint: disable=C0413
-from app import constants # pylint: disable=C0413
+from app import app
+from app import constants
 
 def get_facebook_app_access_token():
     base_uri = 'https://graph.facebook.com/oauth/access_token?client_id={}' \

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -2,7 +2,7 @@ import sys
 from flask import json
 from tests.test_case import *
 from app.pcasts.dao import episodes_dao
-from app import constants # pylint: disable=C0413
+from app import constants
 
 class BookmarksTestCase(TestCase):
 

--- a/tests/test_episodes.py
+++ b/tests/test_episodes.py
@@ -2,7 +2,7 @@ import sys
 from flask import json
 from tests.test_case import *
 from app.pcasts.dao import episodes_dao, series_dao, users_dao
-from app import constants # pylint: disable=C0413
+from app import constants
 
 class EpisodeTestCase(TestCase):
 

--- a/tests/test_listening_history.py
+++ b/tests/test_listening_history.py
@@ -2,7 +2,7 @@ import sys
 from flask import json
 from tests.test_case import *
 from app.pcasts.dao import episodes_dao
-from app import constants # pylint: disable=C0413
+from app import constants
 
 class ListeningHistoryTestCase(TestCase):
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -4,7 +4,7 @@ from flask import json
 from tests import api_utils
 from app.pcasts.dao import users_dao
 from tests.test_case import *
-from app import constants # pylint: disable=C0413
+from app import constants
 
 class LoginTestCase(TestCase):
 

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -2,7 +2,7 @@ import sys
 from flask import json
 from tests.test_case import *
 from app.pcasts.dao import episodes_dao, users_dao, recommendations_dao
-from app import constants # pylint: disable=C0413
+from app import constants
 
 class RecommendationsTestCase(TestCase):
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,7 +2,7 @@ import sys
 from flask import json
 from tests.test_case import *
 from app.pcasts.dao import episodes_dao, users_dao, series_dao
-from app import constants # pylint: disable=C0413
+from app import constants
 
 class SearchTestCase(TestCase):
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2,7 +2,7 @@ import sys
 import json
 from tests.test_case import *
 from app.pcasts.dao import series_dao, subscriptions_dao
-from app import constants # pylint: disable=C0413
+from app import constants
 
 class SeriesTestCase(TestCase):
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,8 +3,8 @@ import config
 import requests
 from tests.api_utils import *
 from app import constants
-from app.pcasts.models._all import * # pylint: disable=C0413
-from app.pcasts.utils.db_utils import * # pylint: disable=C0413
+from app.pcasts.models._all import *
+from app.pcasts.utils.db_utils import *
 from app.pcasts.dao.sessions_dao import *
 from app.pcasts.dao.users_dao import *
 


### PR DESCRIPTION
[Updated the bible .pylintrc a while ago to ignore C0413](https://github.com/cuappdev/bible/commit/4654407a83539297cc3835f9c6d625bcb9f5cb76), should be pretty obvious that imports should normally be at the top of module and the disable are kinda gross. 

Linter warnings should disappear by pulling down the bible if you haven't done so already