### PR TITLE
Add is_following and is_subscribed fields to feed, reorg logic

### DIFF
--- a/src/app/pcasts/controllers/__init__.py
+++ b/src/app/pcasts/controllers/__init__.py
@@ -9,7 +9,8 @@ from app.pcasts.dao import users_dao, \
   recommendations_dao, \
   followings_dao, \
   listening_histories_dao, \
-  itunes_dao
+  itunes_dao, \
+  feed_dao
 
 from app.pcasts.utils.authorize import *
 from app.pcasts.models._all import *

--- a/src/app/pcasts/dao/feed_dao.py
+++ b/src/app/pcasts/dao/feed_dao.py
@@ -81,27 +81,27 @@ def merge_sorted_feed_sources(sources, contexts, page_size):
 def attach_fields_to_json(feed_element, feed_element_json, user):
   if feed_element.context == FeedContexts.FOLLOWING_RECOMMENDATION:
     feed_element_json['context_supplier']['is_following'] = users_dao.\
-        is_following_user(
-            user.id,
-            feed_element_json['context_supplier']['id']
-        )
+      is_following_user(
+          user.id,
+          feed_element_json['context_supplier']['id']
+      )
     feed_element_json['content']['series']['is_subscribed'] = series_dao.\
-        is_subscribed_by_user(
-            feed_element_json['content']['series']['id'],
-            user.id
-        )
+      is_subscribed_by_user(
+          feed_element_json['content']['series']['id'],
+          user.id
+      )
   elif feed_element.context == FeedContexts.FOLLOWING_SUBSCRIPTION:
     feed_element_json['context_supplier']['is_following'] = users_dao.\
-        is_following_user(
-            user.id,
-            feed_element_json['context_supplier']['id']
-        )
+      is_following_user(
+          user.id,
+          feed_element_json['context_supplier']['id']
+      )
   elif feed_element.context == FeedContexts.NEW_SUBSCRIBED_EPISODE:
     feed_element_json['content']['series']['is_subscribed'] = series_dao.\
-        is_subscribed_by_user(
-            feed_element_json['content']['series']['id'],
-            user.id
-        )
+      is_subscribed_by_user(
+          feed_element_json['content']['series']['id'],
+          user.id
+      )
 
   return feed_element_json
 

--- a/src/app/pcasts/dao/feed_dao.py
+++ b/src/app/pcasts/dao/feed_dao.py
@@ -1,0 +1,170 @@
+import heapq
+import time
+from app.pcasts.dao import users_dao, episodes_dao, series_dao
+from . import *
+
+class Enum(set):
+  def __getattr__(self, name):
+    if name in self:
+      return name
+    raise AttributeError
+
+FeedContexts = Enum(['FOLLOWING_RECOMMENDATION',
+                     'FOLLOWING_SUBSCRIPTION',
+                     'NEW_SUBSCRIBED_EPISODE'])
+
+def get_feed(user, maxtime, page_size):
+  following_recommendations = \
+    get_following_recommendations(user.id, maxtime, page_size)
+  following_subscriptions = \
+    get_following_subscriptions(user.id, maxtime, page_size)
+  new_subscribed_episodes = \
+    get_new_subscribed_episodes(user.id, maxtime, page_size)
+
+  # TODO - huge hack, fix later
+  augmented_episodes = []
+  for e in new_subscribed_episodes:
+    e.created_at = e.pub_date
+    augmented_episodes.append(e)
+
+  feed = merge_sorted_feed_sources(
+      [
+          following_recommendations,
+          following_subscriptions,
+          augmented_episodes
+      ],
+      [
+          FeedContexts.FOLLOWING_RECOMMENDATION,
+          FeedContexts.FOLLOWING_SUBSCRIPTION,
+          FeedContexts.NEW_SUBSCRIBED_EPISODE
+      ],
+      page_size)
+
+  return feed
+
+def merge_sorted_feed_sources(sources, contexts, page_size):
+  """
+  Given a list of sources from which to generate a feed page, this function
+    merges the lists together in descending order of when the elements were
+    created.
+
+  Args:
+      sources (list): A list where each element is a list of models containing
+        information for a feed element. Each sublist must already be sorted
+        by descending time.
+      contexts (list): A list where contexts[i] is the `FeedContexts` type
+        of sources[i].
+      page_size (int): Desired length of feed page.
+
+  Returns:
+      list: A list of `FeedElements` of length
+        min(page_size, sum([len(source) for source in sources])) that is
+        sorted by descending time created.
+  """
+  sources = [list(reversed(s)) for s in sources]  # reverse so we can .pop()
+  result, heap, count = [], [], 0
+  for source_idx, s in enumerate(sources):
+    if s:
+      item = s.pop()
+      heapq.heappush(heap, (-time.mktime(item.created_at.timetuple()),
+                            item, source_idx))
+  while len(heap) > 0 and count < page_size:  #pylint: disable=C1801
+    _, item, source_idx = heapq.heappop(heap)
+    result.append(FeedElement(item, contexts[source_idx]))
+    if sources[source_idx]:
+      raw_content = sources[source_idx].pop()
+      heapq.heappush(heap, (-time.mktime(raw_content.created_at.timetuple()),
+                            raw_content, source_idx))
+    count += 1
+  return result
+
+def attach_fields_to_json(feed_element, feed_element_json, user):
+  if feed_element.context == FeedContexts.FOLLOWING_RECOMMENDATION:
+    feed_element_json['context_supplier']['is_following'] = users_dao.\
+        is_following_user(
+            user.id,
+            feed_element_json['context_supplier']['id']
+        )
+    feed_element_json['content']['series']['is_subscribed'] = series_dao.\
+        is_subscribed_by_user(
+            feed_element_json['content']['series']['id'],
+            user.id
+        )
+  elif feed_element.context == FeedContexts.FOLLOWING_SUBSCRIPTION:
+    feed_element_json['context_supplier']['is_following'] = users_dao.\
+        is_following_user(
+            user.id,
+            feed_element_json['context_supplier']['id']
+        )
+  elif feed_element.context == FeedContexts.NEW_SUBSCRIBED_EPISODE:
+    feed_element_json['content']['series']['is_subscribed'] = series_dao.\
+        is_subscribed_by_user(
+            feed_element_json['content']['series']['id'],
+            user.id
+        )
+
+  return feed_element_json
+
+def get_following_subscriptions(user_id, maxtime, page_size):
+  followings = followings_dao.get_followings(user_id)
+  following_ids = [f.followed_id for f in followings]
+  maxdatetime = datetime.datetime.fromtimestamp(int(maxtime))
+  subscriptions = Subscription.query \
+    .filter(Subscription.user_id.in_(following_ids),
+            Subscription.created_at <= maxdatetime) \
+    .order_by(Subscription.created_at.desc()) \
+    .limit(page_size) \
+    .all()
+  series = series_dao.\
+    get_multiple_series([s.series_id for s in subscriptions], user_id)
+
+  series_id_to_series = {s.id:s for s in series}
+  for sub in subscriptions:
+    sub.series = series_id_to_series[sub.series_id]
+
+  return subscriptions
+
+def get_following_recommendations(user_id, maxtime, page_size):
+  followings = followings_dao.get_followings(user_id)
+  following_ids = [f.followed_id for f in followings]
+  maxdatetime = datetime.datetime.fromtimestamp(int(maxtime))
+  recommendations = Recommendation.query \
+    .filter(Recommendation.user_id.in_(following_ids),
+            Recommendation.created_at <= maxdatetime) \
+    .order_by(Recommendation.created_at.desc()) \
+    .limit(page_size) \
+    .all()
+  episodes = episodes_dao.\
+    get_episodes([r.episode_id for r in recommendations], user_id)
+
+  episode_id_to_episode = {e.id:e for e in episodes}
+  for r in recommendations:
+    r.episode = episode_id_to_episode[r.episode_id]
+
+  return recommendations
+
+def get_new_subscribed_episodes(user_id, maxtime, page_size):
+  subscriptions = subscriptions_dao.get_user_subscriptions(user_id, user_id)
+  series_ids = [s.series_id for s in subscriptions]
+  maxdatetime = datetime.datetime.fromtimestamp(int(maxtime))
+  return episodes_dao.get_episodes_maxtime(
+      user_id,
+      series_ids,
+      maxdatetime,
+      page_size
+  )
+
+class FeedElement(object):
+
+  def __init__(self, raw_content, context):
+    self.context = context
+    self.time = int(time.mktime(raw_content.created_at.timetuple()))
+    if context == FeedContexts.FOLLOWING_RECOMMENDATION:
+      self.context_supplier = raw_content.user
+      self.content = raw_content.episode
+    elif context == FeedContexts.FOLLOWING_SUBSCRIPTION:
+      self.context_supplier = raw_content.user
+      self.content = raw_content.series
+    elif context == FeedContexts.NEW_SUBSCRIBED_EPISODE:
+      self.context_supplier = raw_content.series
+      self.content = raw_content

--- a/src/app/pcasts/dao/followings_dao.py
+++ b/src/app/pcasts/dao/followings_dao.py
@@ -1,6 +1,6 @@
 import datetime
 import time
-from app.pcasts.dao import users_dao, episodes_dao, series_dao
+from app.pcasts.dao import users_dao
 from . import *
 
 def get_followings(user_id):
@@ -50,44 +50,6 @@ def delete_following(follower_id, followed_id):
     db_utils.delete_model(maybe_following)
   else:
     raise Exception("Specified following does not exist")
-
-def get_following_recommendations(user_id, maxtime, page_size):
-  followings = get_followings(user_id)
-  following_ids = [f.followed_id for f in followings]
-  maxdatetime = datetime.datetime.fromtimestamp(int(maxtime))
-  recommendations = Recommendation.query \
-    .filter(Recommendation.user_id.in_(following_ids),
-            Recommendation.created_at <= maxdatetime) \
-    .order_by(Recommendation.created_at.desc()) \
-    .limit(page_size) \
-    .all()
-  episodes = episodes_dao.\
-    get_episodes([r.episode_id for r in recommendations], user_id)
-
-  episode_id_to_episode = {e.id:e for e in episodes}
-  for r in recommendations:
-    r.episode = episode_id_to_episode[r.episode_id]
-
-  return recommendations
-
-def get_following_subscriptions(user_id, maxtime, page_size):
-  followings = get_followings(user_id)
-  following_ids = [f.followed_id for f in followings]
-  maxdatetime = datetime.datetime.fromtimestamp(int(maxtime))
-  subscriptions = Subscription.query \
-    .filter(Subscription.user_id.in_(following_ids),
-            Subscription.created_at <= maxdatetime) \
-    .order_by(Subscription.created_at.desc()) \
-    .limit(page_size) \
-    .all()
-  series = series_dao.\
-    get_multiple_series([s.series_id for s in subscriptions], user_id)
-
-  series_id_to_series = {s.id:s for s in series}
-  for sub in subscriptions:
-    sub.series = series_id_to_series[sub.series_id]
-
-  return subscriptions
 
 def attach_is_following_to_json(my_id, followings_json):
   for json in followings_json:

--- a/src/app/pcasts/dao/subscriptions_dao.py
+++ b/src/app/pcasts/dao/subscriptions_dao.py
@@ -1,5 +1,5 @@
 import datetime
-from app.pcasts.dao import series_dao, episodes_dao
+from app.pcasts.dao import series_dao
 from . import *
 
 def get_user_subscriptions(their_id, my_id):
@@ -54,14 +54,3 @@ def delete_subscription(user_id, series_id):
     return db_utils.delete_model(maybe_subscription)
   else:
     raise Exception("Specified subscription does not exist")
-
-def get_new_subscribed_episodes(user_id, maxtime, page_size):
-  subscriptions = get_user_subscriptions(user_id, user_id)
-  series_ids = [s.series_id for s in subscriptions]
-  maxdatetime = datetime.datetime.fromtimestamp(int(maxtime))
-  return episodes_dao.get_episodes_maxtime(
-      user_id,
-      series_ids,
-      maxdatetime,
-      page_size
-  )

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -3,7 +3,7 @@ import json
 from tests.test_case import *
 from app.pcasts.dao import subscriptions_dao, series_dao, recommendations_dao, \
   followings_dao, episodes_dao, bookmarks_dao
-from app.pcasts.controllers.get_feed_controller import FeedContexts
+from app.pcasts.dao.feed_dao import FeedContexts
 
 class FeedTestCase(TestCase):
 
@@ -29,17 +29,17 @@ class FeedTestCase(TestCase):
 
   def test_standard_feed(self):
     episode_title1 = 'Colombians to deliver their verdict on peace accord'
-    episode_id1 = episodes_dao.\
-        get_episode_by_title(episode_title1, self.user1.uid).id
+    episode1 = episodes_dao.\
+        get_episode_by_title(episode_title1, self.user1.uid)
 
     episode_title2 = 'Battle of the camera drones'
-    episode_id2 = episodes_dao.\
-        get_episode_by_title(episode_title2, self.user1.uid).id
+    episode2 = episodes_dao.\
+        get_episode_by_title(episode_title2, self.user1.uid)
 
     followings_dao.create_following(self.user1.uid, self.user2.uid)
-    recommendations_dao.create_recommendation(episode_id1, self.user2.user)
+    recommendations_dao.create_recommendation(episode1.id, self.user2.user)
     time.sleep(1)
-    recommendations_dao.create_recommendation(episode_id2, self.user2.user)
+    recommendations_dao.create_recommendation(episode2.id, self.user2.user)
     time.sleep(1)
     subscriptions_dao.create_subscription(self.user2.uid, '1211520413')
     subscriptions_dao.create_subscription(self.user1.uid, '1211520413')
@@ -58,6 +58,30 @@ class FeedTestCase(TestCase):
     for item in response['data']['feed']:
       self.assertEqual(type(item['time']), int)
       self.assertTrue(item['time'] <= maxtime)
+      if item['context'] == FeedContexts.FOLLOWING_SUBSCRIPTION:
+        self.assertTrue(item['context_supplier']['is_following'])
+      elif item['context'] == FeedContexts.FOLLOWING_RECOMMENDATION:
+        self.assertTrue(item['context_supplier']['is_following'])
+        self.assertFalse(item['content']['series']['is_subscribed'])
+      elif item['context'] == FeedContexts.NEW_SUBSCRIBED_EPISODE:
+        self.assertTrue(item['content']['series']['is_subscribed'])
+
+    # Ensure that is_subscribed updates
+    subscriptions_dao.create_subscription(self.user1.uid, episode1.series_id)
+
+    raw_response = self.user1.get('api/v1/feed/?maxtime={}&page_size=5'
+                                  .format(maxtime)).data
+    response = json.loads(raw_response)
+    for item in response['data']['feed']:
+      self.assertEqual(type(item['time']), int)
+      self.assertTrue(item['time'] <= maxtime)
+      if item['context'] == FeedContexts.FOLLOWING_SUBSCRIPTION:
+        self.assertTrue(item['context_supplier']['is_following'])
+      elif item['context'] == FeedContexts.FOLLOWING_RECOMMENDATION:
+        self.assertTrue(item['context_supplier']['is_following'])
+        self.assertTrue(item['content']['series']['is_subscribed'])
+      elif item['context'] == FeedContexts.NEW_SUBSCRIBED_EPISODE:
+        self.assertTrue(item['content']['series']['is_subscribed'])
 
     # Ensure is_bookmarked is working correctly with new subscribed episodes
     subscribed_ep = episodes_dao.get_episodes_by_series('1211520413', 0, 3)[0]


### PR DESCRIPTION
#174 
- for following recommendations, is_following (to supplier) and is_subscribed (in the content[series]) fields are added
- for following subscriptions, is_following field is added to supplier
- new subscribed episodes, add is_subscribed to the content[series] for consistency
- reorganize the logic to fit the other models; serialization is still done in controller, but most of the business logic is moved to feed_dao, and some functions that were in other daos but only used for the feed moved into feed_dao. This way, if the controller needs extra logic like adding these extra fields, it can call a feed_dao method, and we can keep majority of logic at dao level

<img width="643" alt="screen shot 2017-12-06 at 8 23 21 am" src="https://user-images.githubusercontent.com/11747956/33663634-c252e4ca-da5e-11e7-9f40-d9e4240a8263.png">
