### PR TITLE
Change facebook query endpoints from post to get

### DIFF
--- a/src/app/pcasts/controllers/get_facebook_friends.py
+++ b/src/app/pcasts/controllers/get_facebook_friends.py
@@ -8,13 +8,11 @@ class GetFacebookFriends(AppDevController):
     return '/users/facebook/friends/'
 
   def get_methods(self):
-    return ['POST']
+    return ['GET']
 
   @authorize
   def content(self, **kwargs):
-    body = request.data
-    body_json = json.loads(body)
-    access_token = body_json['access_token']
+    access_token = request.headers.get('access_token')
     offset = request.args['offset']
     max_search = request.args['max']
     user = kwargs.get('user')

--- a/src/app/pcasts/controllers/search_facebook_friends_controller.py
+++ b/src/app/pcasts/controllers/search_facebook_friends_controller.py
@@ -8,13 +8,11 @@ class SearchFacebookFriends(AppDevController):
     return '/search/facebook/friends/<query>/'
 
   def get_methods(self):
-    return ['POST']
+    return ['GET']
 
   @authorize
   def content(self, **kwargs):
-    body = request.data
-    body_json = json.loads(body)
-    access_token = body_json['access_token']
+    access_token = request.headers.get('access_token')
     offset = request.args['offset']
     max_search = request.args['max']
     query = request.view_args['query']

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -30,24 +30,16 @@ class FriendsTestCase(TestCase):
         app_access_token=fb_app_token, name='FB Four')
 
     # No Friends
-    payload_1 = {
-        'access_token': fb_user1.tokens[constants.FACEBOOK]
-    }
-    p1_data = json.dumps(payload_1)
-    response = fb_user1.post('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 10), data=p1_data)
+    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
+        .format(0, 10))
     data = json.loads(response.data)['data']
 
     self.assertEquals(data['users'], [])
 
     # 1 Friend
     api_utils.create_facebook_friendship(fb_user1, fb_user2)
-    payload_2 = {
-        'access_token': fb_user2.tokens[constants.FACEBOOK]
-    }
-    p2_data = json.dumps(payload_2)
-    response = fb_user2.post('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 10), data=p2_data)
+    response = fb_user2.get('api/v1/users/facebook/friends/?offset={}&max={}' \
+        .format(0, 10))
     data = json.loads(response.data)['data']
 
     self.assertTrue(len(data['users']) == 1)
@@ -61,8 +53,8 @@ class FriendsTestCase(TestCase):
     fb_user2.post('api/v1/followings/{}/'.format(fb_user3.uid))
     fb_user4.post('api/v1/followings/{}/'.format(fb_user3.uid))
 
-    response = fb_user1.post('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 10), data=p1_data)
+    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
+        .format(0, 10))
     data = json.loads(response.data)['data']
 
     # Ordered by following
@@ -75,14 +67,14 @@ class FriendsTestCase(TestCase):
     self.assertEquals(data['users'][2]['is_following'], False)
 
     #Test limit and offset
-    response = fb_user1.post('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 1), data=p1_data)
+    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
+        .format(0, 1))
     data = json.loads(response.data)['data']
     self.assertTrue(len(data['users']) == 1)
     self.assertEquals(data['users'][0]['id'], fb_user3.uid)
 
-    response = fb_user1.post('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(2, 1), data=p1_data)
+    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
+        .format(2, 1))
     data = json.loads(response.data)['data']
     self.assertTrue(len(data['users']) == 1)
     self.assertEquals(data['users'][0]['id'], fb_user4.uid)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -241,12 +241,8 @@ class SearchTestCase(TestCase):
         app_access_token=fb_app_token, name='FB Four')
 
     # No friends
-    payload_1 = {
-        'access_token': fb_user1.tokens[constants.FACEBOOK]
-    }
-    p1_data = json.dumps(payload_1)
-    response = fb_user1.post('api/v1/search/facebook/friends/' \
-        '{}/?offset={}&max={}'.format("FB", 0, 10), data=p1_data)
+    response = fb_user1.get('api/v1/search/facebook/friends/' \
+        '{}/?offset={}&max={}'.format("FB", 0, 10))
     data = json.loads(response.data)['data']
 
     self.assertEquals(data['users'], [])
@@ -257,8 +253,8 @@ class SearchTestCase(TestCase):
     api_utils.create_facebook_friendship(fb_user1, fb_user4)
     fb_user1.post('api/v1/followings/{}/'.format(fb_user2.uid))
     fb_user2.post('api/v1/followings/{}/'.format(fb_user3.uid))
-    response = fb_user1.post('api/v1/search/facebook/friends/' \
-        '{}/?offset={}&max={}'.format("Two", 0, 10), data=p1_data)
+    response = fb_user1.get('api/v1/search/facebook/friends/' \
+        '{}/?offset={}&max={}'.format("Two", 0, 10))
     data = json.loads(response.data)['data']
 
     self.assertEquals(len(data['users']), 1)
@@ -266,8 +262,8 @@ class SearchTestCase(TestCase):
 
 
     # 4 Friends (Search two)
-    response = fb_user1.post('api/v1/search/facebook/friends/' \
-        '{}/?offset={}&max={}'.format("tw", 0, 10), data=p1_data)
+    response = fb_user1.get('api/v1/search/facebook/friends/' \
+        '{}/?offset={}&max={}'.format("tw", 0, 10))
     data = json.loads(response.data)['data']
 
     self.assertEquals(data['users'][0]['id'], fb_user2.uid)
@@ -276,16 +272,16 @@ class SearchTestCase(TestCase):
     self.assertEquals(data['users'][1]['is_following'], False)
 
     # Limit
-    response = fb_user1.post('api/v1/search/facebook/friends/' \
-        '{}/?offset={}&max={}'.format("t", 0, 1), data=p1_data)
+    response = fb_user1.get('api/v1/search/facebook/friends/' \
+        '{}/?offset={}&max={}'.format("t", 0, 1))
     data = json.loads(response.data)['data']
 
     self.assertEquals(len(data['users']), 1)
     uid = data['users'][0]['id']
 
     # Offset
-    response = fb_user1.post('api/v1/search/facebook/friends/' \
-        '{}/?offset={}&max={}'.format("t", 1, 1), data=p1_data)
+    response = fb_user1.get('api/v1/search/facebook/friends/' \
+        '{}/?offset={}&max={}'.format("t", 1, 1))
     data = json.loads(response.data)['data']
 
     self.assertEquals(len(data['users']), 1)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -56,7 +56,7 @@ class TestUser(object):
       self.session_token = response['session']['session_token']
 
   def post(self, url, data=None):
-    header = {"Authorization": "Bearer {}".format(self.session_token)}
+    header = self.init_header()
     if data is None:
       response = self.test_client.post(url, headers=header)
     else:
@@ -64,7 +64,7 @@ class TestUser(object):
     return response
 
   def get(self, url, data=None):
-    header = {"Authorization": "Bearer {}".format(self.session_token)}
+    header = self.init_header()
     if data is None:
       response = self.test_client.get(url, headers=header)
     else:
@@ -72,12 +72,19 @@ class TestUser(object):
     return response
 
   def delete(self, url, data=None):
-    header = {"Authorization": "Bearer {}".format(self.session_token)}
+    header = self.init_header()
     if data is None:
       response = self.test_client.delete(url, headers=header)
     else:
       response = self.test_client.delete(url, headers=header, data=data)
     return response
+
+  def init_header(self):
+    if constants.FACEBOOK in self.tokens:
+      return {"Authorization": "Bearer {}".format(self.session_token),
+              "access_token" : self.tokens[constants.FACEBOOK]}
+    else:
+      return {"Authorization": "Bearer {}".format(self.session_token)}
 
 def initTestUser():
   TestUser.goog_user_count = 0


### PR DESCRIPTION
Moved the api tokens from request body to headers making our endpoints conform to HTTP standards