### PR TITLE
Daniel/simpleDiscover

### DIFF
--- a/src/app/pcasts/controllers/discover_episodes_for_topic_controller.py
+++ b/src/app/pcasts/controllers/discover_episodes_for_topic_controller.py
@@ -12,5 +12,8 @@ class DiscoverEpisodesForTopicController(AppDevController):
   def content(self, **kwargs):
     user_id = kwargs.get('user').id
     topic_id = request.view_args['topic_id']
-    episodes = discover_dao.get_episodes_for_topic(topic_id, user_id)
+    offset = request.args['offset']
+    max_search = request.args['max']
+    episodes = discover_dao.get_episodes_for_topic(topic_id, user_id, offset, \
+        max_search)
     return {'episodes': [episode_schema.dump(e).data for e in episodes]}

--- a/src/app/pcasts/controllers/discover_series_for_topic_controller.py
+++ b/src/app/pcasts/controllers/discover_series_for_topic_controller.py
@@ -12,5 +12,8 @@ class DiscoverSeriesForTopicController(AppDevController):
   def content(self, **kwargs):
     user_id = kwargs.get('user').id
     topic_id = request.view_args['topic_id']
-    series = discover_dao.get_series_for_topic(topic_id, user_id)
+    offset = request.args['offset']
+    max_search = request.args['max']
+    series = discover_dao.get_series_for_topic(topic_id, user_id, offset, \
+        max_search)
     return {'series': [series_schema.dump(s).data for s in series]}

--- a/src/app/pcasts/dao/discover_dao.py
+++ b/src/app/pcasts/dao/discover_dao.py
@@ -1,6 +1,9 @@
 import os
 import requests
 from . import *
+from app import constants
+from app import config
+from app.pcasts.utils import topic_utils
 
 def request_podcast_ml(url):
   try:
@@ -10,13 +13,59 @@ def request_podcast_ml(url):
   except requests.exceptions.ConnectionError:
     raise Exception('Could not connect to podcast-ml')
 
-def get_series_for_topic(topic_id, user_id):
-  response = request_podcast_ml('/api/v1/series/topic/{}'.format(topic_id))
-  return series_dao.get_multiple_series(response['data']['series_ids'], user_id)
+def get_series_for_topic(topic_id, user_id, offset, max_search):
+  if config.ML_ENABLED:
+    response = request_podcast_ml('/api/v1/series/topic/{}'.format(topic_id))
+    return series_dao.get_multiple_series(response['data']['series_ids'], \
+        user_id)
+  else:
+    topic_id = int(topic_id)
+    series = []
+    if topic_id in topic_utils.topic_id_offset:
+      topic_id = topic_utils.translate_topic_id(topic_id)
+      series = Series.query.\
+          filter(((Series.topic_id.op('&')(topic_id))) == topic_id).\
+          order_by(Series.subscribers_count.desc()).\
+          offset(offset).\
+          limit(max_search).\
+          all()
+    if topic_id in topic_utils.subtopic_id_offset:
+      subtopic_id = topic_utils.translate_subtopic_id(topic_id)
+      series = Series.query.\
+          filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
+          order_by(Series.subscribers_count.desc()).\
+          offset(offset).\
+          limit(max_search).\
+          all()
+    return series
 
-def get_episodes_for_topic(topic_id, user_id):
-  response = request_podcast_ml('/api/v1/episodes/topic/{}'.format(topic_id))
-  return episodes_dao.get_episodes(response['data']['episode_ids'], user_id)
+
+def get_episodes_for_topic(topic_id, user_id, offset, max_search):
+  if config.ML_ENABLED:
+    response = request_podcast_ml('/api/v1/episodes/topic/{}'.format(topic_id))
+    return episodes_dao.get_episodes(response['data']['episode_ids'], user_id)
+  else:
+    episodes = []
+    topic_id = int(topic_id)
+    if topic_id in topic_utils.topic_id_offset:
+      topic_id = topic_utils.translate_topic_id(topic_id)
+      episodes = Episode.query.join(Series). \
+          filter((Series.topic_id.op('&')(topic_id)) == topic_id).\
+          filter(Episode.series_id == Series.id).\
+          order_by(Episode.recommendations_count.desc()).\
+          offset(offset).\
+          limit(max_search).\
+          all()
+    if topic_id in topic_utils.subtopic_id_offset:
+      subtopic_id = topic_utils.translate_subtopic_id(topic_id)
+      episodes = Episode.query.join(Series). \
+          filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
+          filter(Episode.series_id == Series.id).\
+          order_by(Episode.recommendations_count.desc()).\
+          offset(offset).\
+          limit(max_search).\
+          all()
+    return episodes
 
 def get_series_for_user(user_id):
   response = request_podcast_ml('/api/v1/series/user/')

--- a/src/app/pcasts/dao/discover_dao.py
+++ b/src/app/pcasts/dao/discover_dao.py
@@ -29,7 +29,7 @@ def get_series_for_topic(topic_id, user_id, offset, max_search):
           offset(offset).\
           limit(max_search).\
           all()
-    if topic_id in topic_utils.subtopic_id_offset:
+    elif topic_id in topic_utils.subtopic_id_offset:
       subtopic_id = topic_utils.translate_subtopic_id(topic_id)
       series = Series.query.\
           filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
@@ -37,6 +37,8 @@ def get_series_for_topic(topic_id, user_id, offset, max_search):
           offset(offset).\
           limit(max_search).\
           all()
+    else:
+      raise Exception("Invalid topic id " + str(topic_id))
     return series
 
 
@@ -56,7 +58,7 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
           offset(offset).\
           limit(max_search).\
           all()
-    if topic_id in topic_utils.subtopic_id_offset:
+    elif topic_id in topic_utils.subtopic_id_offset:
       subtopic_id = topic_utils.translate_subtopic_id(topic_id)
       episodes = Episode.query.join(Series). \
           filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
@@ -65,6 +67,8 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
           offset(offset).\
           limit(max_search).\
           all()
+    else:
+      raise Exception("Invalid topic id " + str(topic_id))
     return episodes
 
 def get_series_for_user(user_id):

--- a/src/app/pcasts/models/series.py
+++ b/src/app/pcasts/models/series.py
@@ -1,4 +1,5 @@
 from . import *
+from app.pcasts.utils import topic_utils
 
 class Series(Base):
   __tablename__ = 'series'
@@ -13,6 +14,8 @@ class Series(Base):
   feed_url = db.Column(db.Text, nullable=False)
   genres = db.Column(db.Text) # semicolon-separated
   subscribers_count = db.Column(db.Integer, nullable=False)
+  topic_id = db.Column(db.Integer)
+  subtopic_id = db.Column(db.BigInteger)
 
   def __init__(self, **kwargs):
     self.id = kwargs.get('id')
@@ -24,3 +27,5 @@ class Series(Base):
     self.feed_url = kwargs.get('feed_url')
     self.genres = ';'.join(kwargs.get('genres', []))
     self.subscribers_count = kwargs.get('subscribers_count', 0)
+    self.topic_id, self.subtopic_id = \
+        topic_utils.get_topic_ids(kwargs.get('genres', []))

--- a/src/app/pcasts/utils/topic_utils.py
+++ b/src/app/pcasts/utils/topic_utils.py
@@ -1,45 +1,53 @@
 import json
 from app import constants
 
-# Returns a mapping from topic name to least significant bit. Used for the DB
+# Returns a mapping from (sub)topic name to least significant bit and (sub)topic
+# id to least significant bit.
 def create_topics_mappings():
   topic_bit_position, subtopic_bit_position = 0, 0
-  topic_to_id, subtopic_to_id = {}, {}
+  topic_name_offset, subtopic_name_offset = {}, {}
+  topic_id_offset, subtopic_id_offset = {}, {}
+  name_to_id = {}
   topics, subtopics = [], []
 
   json_data = open(constants.TOPIC_FILE)
   data = json.load(json_data)
   for topic in data['topics']:
+    name_to_id[topic['name']] = topic['id']
     topics.append(topic['name'])
     for subtopic in topic['subtopics']:
-      subtopics.append(subtopic["name"])
+      name_to_id[subtopic['name']] = subtopic['id']
+      subtopics.append(subtopic['name'])
 
   topics.sort()
   subtopics.sort()
   for topic in topics:
-    topic_to_id[topic] = topic_bit_position
+    topic_name_offset[topic] = topic_bit_position
+    topic_id_offset[name_to_id[topic]] = topic_bit_position
     topic_bit_position += 1
 
   for subtopic in subtopics:
-    subtopic_to_id[subtopic] = subtopic_bit_position
+    subtopic_name_offset[subtopic] = subtopic_bit_position
+    subtopic_id_offset[name_to_id[subtopic]] = subtopic_bit_position
     subtopic_bit_position += 1
 
-  return topic_to_id, subtopic_to_id
+  return topic_id_offset, subtopic_id_offset, \
+         topic_name_offset, subtopic_name_offset
 
 # Returns an id that represents both the old topics and the new topic
 # identified by subtopic_offset
 def create_topic_id(old_topic_id, topic_name):
   bitmask = 0
-  if topic_name in topic_map:
-    bitmask = 1 << topic_map[topic_name]
+  if topic_name in topic_name_offset:
+    bitmask = 1 << topic_name_offset[topic_name]
   return old_topic_id | bitmask
 
 # Returns an id that represents both the old subtopics and the new subtopic
 # identified by subtopic_offset
 def create_subtopic_id(old_topic_id, subtopic_name):
   bitmask = 0
-  if subtopic_name in subtopic_map:
-    bitmask = 1 << subtopic_map[subtopic_name]
+  if subtopic_name in subtopic_name_offset:
+    bitmask = 1 << subtopic_name_offset[subtopic_name]
   return old_topic_id | bitmask
 
 def get_topic_ids(genres):
@@ -50,4 +58,12 @@ def get_topic_ids(genres):
     subtopic_id = create_subtopic_id(subtopic_id, genre)
   return topic_id, subtopic_id
 
-topic_map, subtopic_map = create_topics_mappings()
+def translate_topic_id(topic_id):
+  return 1 << topic_id_offset[topic_id]
+
+def translate_subtopic_id(topic_id):
+  return 1 << subtopic_id_offset[topic_id]
+
+#Maps from topic id to the offset bit and topic name to offset bits
+topic_id_offset, subtopic_id_offset, topic_name_offset, \
+  subtopic_name_offset = create_topics_mappings()

--- a/src/app/pcasts/utils/topic_utils.py
+++ b/src/app/pcasts/utils/topic_utils.py
@@ -1,0 +1,53 @@
+import json
+from app import constants
+
+# Returns a mapping from topic name to least significant bit. Used for the DB
+def create_topics_mappings():
+  topic_bit_position, subtopic_bit_position = 0, 0
+  topic_to_id, subtopic_to_id = {}, {}
+  topics, subtopics = [], []
+
+  json_data = open(constants.TOPIC_FILE)
+  data = json.load(json_data)
+  for topic in data['topics']:
+    topics.append(topic['name'])
+    for subtopic in topic['subtopics']:
+      subtopics.append(subtopic["name"])
+
+  topics.sort()
+  subtopics.sort()
+  for topic in topics:
+    topic_to_id[topic] = topic_bit_position
+    topic_bit_position += 1
+
+  for subtopic in subtopics:
+    subtopic_to_id[subtopic] = subtopic_bit_position
+    subtopic_bit_position += 1
+
+  return topic_to_id, subtopic_to_id
+
+# Returns an id that represents both the old topics and the new topic
+# identified by subtopic_offset
+def create_topic_id(old_topic_id, topic_name):
+  bitmask = 0
+  if topic_name in topic_map:
+    bitmask = 1 << topic_map[topic_name]
+  return old_topic_id | bitmask
+
+# Returns an id that represents both the old subtopics and the new subtopic
+# identified by subtopic_offset
+def create_subtopic_id(old_topic_id, subtopic_name):
+  bitmask = 0
+  if subtopic_name in subtopic_map:
+    bitmask = 1 << subtopic_map[subtopic_name]
+  return old_topic_id | bitmask
+
+def get_topic_ids(genres):
+  topic_id = 0
+  subtopic_id = 0
+  for genre in genres:
+    topic_id = create_topic_id(topic_id, genre)
+    subtopic_id = create_subtopic_id(subtopic_id, genre)
+  return topic_id, subtopic_id
+
+topic_map, subtopic_map = create_topics_mappings()

--- a/src/config.py
+++ b/src/config.py
@@ -55,6 +55,9 @@ TEST_PODCAST_DB_URL = 'mysql://{}:{}@{}/{}?charset=utf8mb4'.format(
 FACEBOOK_APP_ID = os.environ.get('FACEBOOK_APP_ID')
 FACEBOOK_APP_SECRET = os.environ.get('FACEBOOK_APP_SECRET')
 
+# Discover
+ML_ENABLED = False
+
 class Config(object):
   DEBUG = False
   TESTING = False

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -60,21 +60,15 @@ class DiscoverTestCase(TestCase):
     self.assertFalse(data['success'])
 
   @mock.patch('requests.get', side_effect=mocked_requests_get)
-<<<<<<< HEAD
   def test_series_for_user(self, mock_get):
-    response = self.user1.get('api/v1/discover/series/user/')
-=======
-  def test_series_for_topic(self, mock_get):
-    response = self.user1.get('api/v1/discover/series/topic/1/?offset=0&max=1')
->>>>>>> master
+    response = self.user1.get('api/v1/discover/series/user/?offset=0&max=1')
     series = json.loads(response.data)['data']['series']
-    ids = [int(ser['id']) for ser in series]
+    ids = [int(show['id']) for show in series]
     self.assertEquals(series_ids, ids)
 
   @mock.patch('requests.get', side_effect=mocked_requests_get)
-<<<<<<< HEAD
   def test_episodes_for_user(self, mock_get):
-    response = self.user1.get('api/v1/discover/episodes/user/')
+    response = self.user1.get('api/v1/discover/episodes/user/?offset=0&max=1')
     episodes = json.loads(response.data)['data']['episodes']
     ids = [int(ep['id']) for ep in episodes]
     self.assertEquals(episode_ids, ids)
@@ -84,10 +78,6 @@ class DiscoverTestCase(TestCase):
     config.ML_ENABLED = True
     response = self.user1.get('api/v1/discover/series/topic/1323/' +
                               '?offset=0&max=0')
-=======
-  def test_series_for_user(self, mock_get):
-    response = self.user1.get('api/v1/discover/series/user/?offset=0&max=1')
->>>>>>> master
     series = json.loads(response.data)['data']['series']
     ids = [int(show['id']) for show in series]
     self.assertEquals(series_ids, ids)
@@ -103,27 +93,18 @@ class DiscoverTestCase(TestCase):
 
   @mock.patch('requests.get', side_effect=mocked_requests_get)
   def test_episodes_for_topic(self, mock_get):
-<<<<<<< HEAD
     config.ML_ENABLED = True
     response = self.user1.get('api/v1/discover/episodes/topic/1323/' +
                               '?offset=0&max=10')
-=======
-    response = self.user1.get('api/v1/discover/episodes/topic/3/?offset=0&max=1')
->>>>>>> master
     episodes = json.loads(response.data)['data']['episodes']
     ids = [int(ep['id']) for ep in episodes]
     self.assertEquals(episode_ids, ids)
 
   @mock.patch('requests.get', side_effect=mocked_requests_get)
-<<<<<<< HEAD
   def test_episodes_for_subtopic(self, mock_get):
     config.ML_ENABLED = True
     response = self.user1.get('api/v1/discover/episodes/topic/1443/' +
                               '?offset=0&max=10')
-=======
-  def test_episodes_for_user(self, mock_get):
-    response = self.user1.get('api/v1/discover/episodes/user/?offset=0&max=1')
->>>>>>> master
     episodes = json.loads(response.data)['data']['episodes']
     ids = [int(ep['id']) for ep in episodes]
     self.assertEquals(episode_ids, ids)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -2,7 +2,9 @@ import sys
 from flask import json
 from tests.test_case import *
 from app import constants # pylint: disable=C0413
+from app import config
 import mock
+from app.pcasts.dao import episodes_dao, series_dao, recommendations_dao
 
 series_ids = [s.id for s in Series.query.limit(10).all()]
 episode_ids = [e.id for e in Episode.query.limit(10).all()]
@@ -36,12 +38,21 @@ def mocked_requests_get(*args, **kwargs):
 
 class DiscoverTestCase(TestCase):
 
-  @mock.patch('requests.get', side_effect=mocked_requests_get)
-  def test_series_for_topic(self, mock_get):
-    response = self.user1.get('api/v1/discover/series/topic/1/')
-    series = json.loads(response.data)['data']['series']
-    ids = [int(ser['id']) for ser in series]
-    self.assertEquals(series_ids, ids)
+  def setUp(self):
+    super(DiscoverTestCase, self).setUp()
+    Recommendation.query.delete()
+    episodes_dao.clear_all_recommendations_counts()
+    Subscription.query.delete()
+    series_dao.clear_all_subscriber_counts()
+    db_session_commit()
+
+  def tearDown(self):
+    super(DiscoverTestCase, self).tearDown()
+    Recommendation.query.delete()
+    episodes_dao.clear_all_recommendations_counts()
+    Subscription.query.delete()
+    series_dao.clear_all_subscriber_counts()
+    db_session_commit()
 
   @mock.patch('requests.get', side_effect=mocked_requests_get)
   def test_series_for_user(self, mock_get):
@@ -51,20 +62,94 @@ class DiscoverTestCase(TestCase):
     self.assertEquals(series_ids, ids)
 
   @mock.patch('requests.get', side_effect=mocked_requests_get)
-  def test_episodes_for_topic(self, mock_get):
-    response = self.user1.get('api/v1/discover/episodes/topic/3/')
-    episodes = json.loads(response.data)['data']['episodes']
-    ids = [int(ep['id']) for ep in episodes]
-    self.assertEquals(episode_ids, ids)
-
-  @mock.patch('requests.get', side_effect=mocked_requests_get)
   def test_episodes_for_user(self, mock_get):
-    response = self.user1.get('api/v1/discover/episodes/user/')
-    episodes = json.loads(response.data)['data']['episodes']
-    ids = [int(ep['id']) for ep in episodes]
-    self.assertEquals(episode_ids, ids)
+    if config.ML_ENABLED:
+      response = self.user1.get('api/v1/discover/episodes/user/')
+      episodes = json.loads(response.data)['data']['episodes']
+      ids = [int(ep['id']) for ep in episodes]
+      self.assertEquals(episode_ids, ids)
 
   def test_ml_down(self):
     response = self.user1.get('api/v1/discover/episodes/user/')
     data = json.loads(response.data)
     self.assertFalse(data['success'])
+
+  def test_episodes_for_topic_no_ml(self):
+    if config.ML_ENABLED:
+      response = self.user1.get('api/v1/discover/episodes/topic/1304/')
+      episodes = json.loads(response.data)['data']['episodes']
+      ids = [int(ep['id']) for ep in episodes]
+      self.assertEquals(episode_ids, ids)
+    else:
+      # Testing topic: Games and Hobbies
+      episode_title1 = '749 Filter Therapy'
+      episode_id1 = episodes_dao.\
+          get_episode_by_title(episode_title1, self.user1.uid).id
+      episode_title2 = '05-12-11 Brett Beer'
+      episode_id2 = episodes_dao.\
+          get_episode_by_title(episode_title2, self.user1.uid).id
+      self.user1.post('api/v1/recommendations/{}/'.format(episode_id1))
+      self.user2.post('api/v1/recommendations/{}/'.format(episode_id1))
+      self.user1.post('api/v1/recommendations/{}/'.format(episode_id2))
+      request = self.user1.get('api/v1/discover/episodes/topic/1323/'+
+                               '?offset=0&max=25')
+      data = json.loads(request.data)['data']
+      self.assertTrue(data['episodes'][0]['id'] == episode_id1)
+      self.assertTrue(data['episodes'][1]['id'] == episode_id2)
+
+
+  def test_episodes_for_subtopic_no_ml(self):
+    if config.ML_ENABLED:
+      pass
+    else:
+      # Testing subtopics(Philosophy)
+      episode_title1 = '#1: Paul Dini'
+      episode_id1 = episodes_dao.\
+          get_episode_by_title(episode_title1, self.user1.uid).id
+      episode_title2 = 'High income vs High net worth where do you rank?'
+      episode_id2 = episodes_dao.\
+          get_episode_by_title(episode_title2, self.user1.uid).id
+      self.user1.post('api/v1/recommendations/{}/'.format(episode_id1))
+      self.user2.post('api/v1/recommendations/{}/'.format(episode_id1))
+      self.user1.post('api/v1/recommendations/{}/'.format(episode_id2))
+      request = self.user1.get('api/v1/discover/episodes/topic/1443/'+
+                               '?offset=0&max=25')
+      data = json.loads(request.data)['data']
+      self.assertTrue(data['episodes'][0]['id'] == episode_id1)
+      self.assertTrue(data['episodes'][1]['id'] == episode_id2)
+
+  # Tests for disabled ML
+  def test_series_for_topic_no_ml(self):
+    if config.ML_ENABLED:
+      response = self.user1.get('api/v1/discover/series/topic/1304/')
+      series = json.loads(response.data)['data']['series']
+      ids = [int(ep['id']) for ep in series]
+      self.assertEquals(episode_ids, ids)
+    else:
+      #Topic: Games and Hobbies
+      series_id1 = '73329429'
+      series_id2 = '75092679'
+      self.user1.post('api/v1/subscriptions/{}/'.format(series_id1))
+      self.user2.post('api/v1/subscriptions/{}/'.format(series_id1))
+      self.user1.post('api/v1/subscriptions/{}/'.format(series_id2))
+      request = self.user1.get('api/v1/discover/series/topic/1323/' +
+                               '?offset=0&max=25')
+      data = json.loads(request.data)['data']
+      self.assertTrue(int(data['series'][0]['id']) == int(series_id1))
+      self.assertTrue(int(data['series'][1]['id']) == int(series_id2))
+
+  def test_series_for_subtopic_no_ml(self):
+    if config.ML_ENABLED:
+      pass
+    else:
+      # Testing subtopics(Philosophy)
+      series_id1 = '532661418'
+      series_id2 = '896417058'
+      self.user1.post('api/v1/subscriptions/{}/'.format(series_id1))
+      self.user2.post('api/v1/subscriptions/{}/'.format(series_id1))
+      self.user1.post('api/v1/subscriptions/{}/'.format(series_id2))
+      request = self.user1.get('api/v1/discover/series/topic/1443/' +
+                               '?offset=0&max=25')
+      data = json.loads(request.data)['data']
+      self.assertTrue(int(data['series'][0]['id']) == int(series_id1))
+      self.assertTrue(int(data['series'][1]['id']) == int(series_id2))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,21 +9,27 @@ class UsersTestCase(TestCase):
     topic_id = 0
     for topic in topics:
       topic_id = topic_utils.create_topic_id(topic_id, topic)
-    self.assertTrue(topic_id & (1 << topic_utils.topic_map['Arts']))
-    self.assertTrue(topic_id & (1 << topic_utils.topic_map['Business']))
-    self.assertTrue(topic_id & (1 << topic_utils.topic_map['TV & Film']))
-    self.assertTrue(topic_id & (1 << topic_utils.topic_map['Technology']))
-    self.assertFalse(topic_id & (1 << topic_utils.topic_map['Health']))
+    self.assertTrue(topic_id & (1 << topic_utils.topic_name_offset['Arts']))
+    self.assertTrue(topic_id & (1 << topic_utils.topic_name_offset['Business']))
+    self.assertTrue(topic_id & (1 << \
+        topic_utils.topic_name_offset['TV & Film']))
+    self.assertTrue(topic_id & (1 << \
+        topic_utils.topic_name_offset['Technology']))
+    self.assertFalse(topic_id & (1 << \
+        topic_utils.topic_name_offset['Health']))
 
   def test_create_subtopic_id(self):
     subtopics = ["Automotive", "Aviation", "Other Games", "Video Games", "Junk"]
     subtopic_id = 0
     for subtopic in subtopics:
       subtopic_id = topic_utils.create_subtopic_id(subtopic_id, subtopic)
-    self.assertTrue(subtopic_id & (1 << topic_utils.subtopic_map['Automotive']))
-    self.assertTrue(subtopic_id & (1 << topic_utils.subtopic_map['Aviation']))
     self.assertTrue(subtopic_id & (1 << \
-        topic_utils.subtopic_map['Video Games']))
+        topic_utils.subtopic_name_offset['Automotive']))
     self.assertTrue(subtopic_id & (1 << \
-        topic_utils.subtopic_map['Other Games']))
-    self.assertFalse(subtopic_id & (1 << topic_utils.subtopic_map['Outdoor']))
+        topic_utils.subtopic_name_offset['Aviation']))
+    self.assertTrue(subtopic_id & (1 << \
+        topic_utils.subtopic_name_offset['Video Games']))
+    self.assertTrue(subtopic_id & (1 << \
+        topic_utils.subtopic_name_offset['Other Games']))
+    self.assertFalse(subtopic_id & (1 << \
+        topic_utils.subtopic_name_offset['Outdoor']))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+from flask import json
+from tests.test_case import *
+from app.pcasts.utils import topic_utils
+
+class UsersTestCase(TestCase):
+
+  def test_create_topic_id(self):
+    topics = ["Arts", "Business", "Junk", "TV & Film", "Technology"]
+    topic_id = 0
+    for topic in topics:
+      topic_id = topic_utils.create_topic_id(topic_id, topic)
+    self.assertTrue(topic_id & (1 << topic_utils.topic_map['Arts']))
+    self.assertTrue(topic_id & (1 << topic_utils.topic_map['Business']))
+    self.assertTrue(topic_id & (1 << topic_utils.topic_map['TV & Film']))
+    self.assertTrue(topic_id & (1 << topic_utils.topic_map['Technology']))
+    self.assertFalse(topic_id & (1 << topic_utils.topic_map['Health']))
+
+  def test_create_subtopic_id(self):
+    subtopics = ["Automotive", "Aviation", "Other Games", "Video Games", "Junk"]
+    subtopic_id = 0
+    for subtopic in subtopics:
+      subtopic_id = topic_utils.create_subtopic_id(subtopic_id, subtopic)
+    self.assertTrue(subtopic_id & (1 << topic_utils.subtopic_map['Automotive']))
+    self.assertTrue(subtopic_id & (1 << topic_utils.subtopic_map['Aviation']))
+    self.assertTrue(subtopic_id & (1 << \
+        topic_utils.subtopic_map['Video Games']))
+    self.assertTrue(subtopic_id & (1 << \
+        topic_utils.subtopic_map['Other Games']))
+    self.assertFalse(subtopic_id & (1 << topic_utils.subtopic_map['Outdoor']))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ from flask import json
 from tests.test_case import *
 from app.pcasts.utils import topic_utils
 
-class UsersTestCase(TestCase):
+class TestUtilsTestCase(TestCase):
 
   def test_create_topic_id(self):
     topics = ["Arts", "Business", "Junk", "TV & Film", "Technology"]


### PR DESCRIPTION
Discover for episodes/series by topic using subscription counts and recommendation counts.
Changed the db schema for series by adding two flags that represent topic/subtopic to eliminate the lists as strings.
Major drawbacks this faces are loss of the ability to index by topics and some intermediate translation with topic id's to their encoding. Seeing how this version of the endpoint is not permanent, this should not be a problem