### PR TITLE
Manually add topic ids to the episodes database

### DIFF
--- a/src/app/pcasts/__init__.py
+++ b/src/app/pcasts/__init__.py
@@ -45,6 +45,7 @@ from app.pcasts.controllers.discover_episodes_for_topic_controller import *
 from app.pcasts.controllers.discover_episodes_for_user_controller import *
 from app.pcasts.controllers.search_facebook_friends_controller import *
 from app.pcasts.controllers.get_topics_controller import *
+from app.pcasts.dao.series_dao import refresh_series
 
 controllers = [
     GoogleSignInController(),
@@ -94,3 +95,6 @@ for controller in controllers:
       controller.response,
       methods=controller.get_methods()
   )
+
+# Refresh series for temporary fix
+refresh_series()

--- a/src/app/pcasts/dao/series_dao.py
+++ b/src/app/pcasts/dao/series_dao.py
@@ -98,3 +98,12 @@ def get_top_series_by_subscribers(offset, max_search, user_id):
   ]
   found_series = get_multiple_series(found_series_ids, user_id)
   return order_by_ids(found_series_ids, found_series)
+
+#XXX: Temporary fix until we can get cleaner devops
+def refresh_series():
+  series = Series.query.filter(Series.topic_id is not None).all()
+  if len(series) != 0:
+    for show in series:
+      show.topic_id, show.subtopic_id = \
+          topic_utils.get_topic_ids(show.genres.split(";"))
+    db_utils.db_session_commit()


### PR DESCRIPTION
Removed a stray test case(not too sure how or why it didn't trigger) and added the fix for the Series schema