### PR TITLE
Added second ordering to all discover endpoints

### DIFF
--- a/src/app/pcasts/dao/discover_dao.py
+++ b/src/app/pcasts/dao/discover_dao.py
@@ -21,11 +21,13 @@ def get_series_for_topic(topic_id, user_id, offset, max_search):
   else:
     topic_id = int(topic_id)
     series = []
+    # Second ordering by id to resolve ties showing up at different offsets
     if topic_id in topic_utils.topic_id_offset:
       topic_id = topic_utils.translate_topic_id(topic_id)
       series = Series.query.\
           filter(((Series.topic_id.op('&')(topic_id))) == topic_id).\
           order_by(Series.subscribers_count.desc()).\
+          order_by(Series.id).\
           offset(offset).\
           limit(max_search).\
           all()
@@ -34,6 +36,7 @@ def get_series_for_topic(topic_id, user_id, offset, max_search):
       series = Series.query.\
           filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
           order_by(Series.subscribers_count.desc()).\
+          order_by(Series.id).\
           offset(offset).\
           limit(max_search).\
           all()
@@ -52,12 +55,14 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
   else:
     episodes = []
     topic_id = int(topic_id)
+    # Second ordering by id to resolve ties showing up at different offsets
     if topic_id in topic_utils.topic_id_offset:
       topic_id = topic_utils.translate_topic_id(topic_id)
       episodes = Episode.query.join(Series). \
           filter((Series.topic_id.op('&')(topic_id)) == topic_id).\
           filter(Episode.series_id == Series.id).\
           order_by(Episode.recommendations_count.desc()).\
+          order_by(Episode.id).\
           offset(offset).\
           limit(max_search).\
           all()
@@ -67,6 +72,7 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
           filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
           filter(Episode.series_id == Series.id).\
           order_by(Episode.recommendations_count.desc()).\
+          order_by(Episode.id).\
           offset(offset).\
           limit(max_search).\
           all()

--- a/src/app/pcasts/dao/episodes_dao.py
+++ b/src/app/pcasts/dao/episodes_dao.py
@@ -81,12 +81,14 @@ def search_episode(search_name, offset, max_search, user_id):
 
   return get_episodes(possible_episode_ids, user_id)
 
+# Second ordering by id to resolve ties showing up at different offsets
 def get_top_episodes_by_recommenders(offset, max_search, user_id):
   found_episode_ids = [
       tup[0] for tup in
       Episode.query.\
       with_entities(Episode.id, Episode.recommendations_count).\
       order_by(Episode.recommendations_count.desc()).\
+      order_by(Episode.id).\
       offset(offset).\
       limit(max_search).\
       all()

--- a/src/app/pcasts/dao/series_dao.py
+++ b/src/app/pcasts/dao/series_dao.py
@@ -86,12 +86,14 @@ def search_series(search_name, offset, max_search, user_id):
 
   return get_multiple_series(possible_series_ids, user_id)
 
+# Second ordering by id to resolve ties showing up at different offsets
 def get_top_series_by_subscribers(offset, max_search, user_id):
   found_series_ids = [
       tup[0] for tup in
       Series.query.\
       with_entities(Series.id, Series.subscribers_count).\
       order_by(Series.subscribers_count.desc()).\
+      order_by(Series.id).\
       offset(offset).\
       limit(max_search).\
       all()


### PR DESCRIPTION
This will fix #203 
Previously we were just ordering by recommendations/subscriptions so if a lot of series had the same count it was possible for them to appear in different offsets since the ordering is not deterministic. Applying a second deterministic ordering will fix the problem.
This is a temporary fix until ElasticSearch will be rolled out next week(TM)