### PR TITLE
facebook friends enpoint filters by following status

### DIFF
--- a/src/app/pcasts/controllers/get_facebook_friends.py
+++ b/src/app/pcasts/controllers/get_facebook_friends.py
@@ -15,7 +15,7 @@ class GetFacebookFriends(AppDevController):
     access_token = request.headers.get('AccessToken')
     offset = request.args['offset']
     max_search = request.args['max']
-    return_following = request.args['return_following']
+    return_following = request.args.get('return_following', default="true")
     user = kwargs.get('user')
     return_following = True if return_following == 'true' else False
     fb_friend_ids = facebook_utils.get_friend_ids(user.facebook_id, \

--- a/src/app/pcasts/controllers/get_facebook_friends.py
+++ b/src/app/pcasts/controllers/get_facebook_friends.py
@@ -15,12 +15,13 @@ class GetFacebookFriends(AppDevController):
     access_token = request.headers.get('AccessToken')
     offset = request.args['offset']
     max_search = request.args['max']
+    return_following = request.args['return_following']
     user = kwargs.get('user')
-
+    return_following = True if return_following == 'true' else False
     fb_friend_ids = facebook_utils.get_friend_ids(user.facebook_id, \
         access_token)
     users = users_dao.get_users_by_facebook_ids(fb_friend_ids, user.id, \
-        offset, max_search)
+        offset, max_search, return_following)
 
     return {
         'users': [user_schema.dump(u).data for u in users]

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -76,6 +76,18 @@ class FriendsTestCase(TestCase):
     self.assertEquals(data['users'][1]['id'], fb_user4.uid)
     self.assertEquals(data['users'][1]['is_following'], False)
 
+    # test default value of return_following (true)
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}'.format(0, 10))
+    data = json.loads(response.data)['data']
+    self.assertTrue(len(data['users']) == 3)
+    self.assertEquals(data['users'][0]['id'], fb_user3.uid)
+    self.assertEquals(data['users'][0]['is_following'], False)
+    self.assertEquals(data['users'][1]['id'], fb_user2.uid)
+    self.assertEquals(data['users'][1]['is_following'], True)
+    self.assertEquals(data['users'][2]['id'], fb_user4.uid)
+    self.assertEquals(data['users'][2]['is_following'], False)
+
     # Test limit and offset
     response = fb_user1.get('api/v1/users/facebook/friends/' + \
             '?offset={}&max={}&return_following={}'.format(0, 1, 'true'))

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -30,34 +30,33 @@ class FriendsTestCase(TestCase):
         app_access_token=fb_app_token, name='FB Four')
 
     # No Friends
-    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 10))
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}&return_following={}'.format(0, 10, 'true'))
     data = json.loads(response.data)['data']
-
     self.assertEquals(data['users'], [])
 
     # 1 Friend
     api_utils.create_facebook_friendship(fb_user1, fb_user2)
-    response = fb_user2.get('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 10))
+    response = fb_user2.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}&return_following={}'.format(0, 10, 'true'))
     data = json.loads(response.data)['data']
 
     self.assertTrue(len(data['users']) == 1)
     self.assertEquals(data['users'][0]['id'], fb_user1.uid)
     self.assertEquals(data['users'][0]['is_following'], False)
 
-    #3 Friends with different followings
+    # 3 Friends with different followings
     api_utils.create_facebook_friendship(fb_user1, fb_user3)
     api_utils.create_facebook_friendship(fb_user1, fb_user4)
     fb_user1.post('api/v1/followings/{}/'.format(fb_user2.uid))
     fb_user2.post('api/v1/followings/{}/'.format(fb_user3.uid))
     fb_user4.post('api/v1/followings/{}/'.format(fb_user3.uid))
 
-    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 10))
+    # return_following true (ordered by followings)
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}&return_following={}'.format(0, 10, 'true'))
     data = json.loads(response.data)['data']
 
-    # Ordered by following
     self.assertTrue(len(data['users']) == 3)
     self.assertEquals(data['users'][0]['id'], fb_user3.uid)
     self.assertEquals(data['users'][0]['is_following'], False)
@@ -66,15 +65,32 @@ class FriendsTestCase(TestCase):
     self.assertEquals(data['users'][2]['id'], fb_user4.uid)
     self.assertEquals(data['users'][2]['is_following'], False)
 
-    #Test limit and offset
-    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(0, 1))
+
+    # return_following false (ordered by followings)
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}&return_following={}'.format(0, 10, 'false'))
+    data = json.loads(response.data)['data']
+    self.assertTrue(len(data['users']) == 2)
+    self.assertEquals(data['users'][0]['id'], fb_user3.uid)
+    self.assertEquals(data['users'][0]['is_following'], False)
+    self.assertEquals(data['users'][1]['id'], fb_user4.uid)
+    self.assertEquals(data['users'][1]['is_following'], False)
+
+    # Test limit and offset
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}&return_following={}'.format(0, 1, 'true'))
     data = json.loads(response.data)['data']
     self.assertTrue(len(data['users']) == 1)
     self.assertEquals(data['users'][0]['id'], fb_user3.uid)
 
-    response = fb_user1.get('api/v1/users/facebook/friends/?offset={}&max={}' \
-        .format(2, 1))
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}&return_following={}'.format(2, 1, 'true'))
+    data = json.loads(response.data)['data']
+    self.assertTrue(len(data['users']) == 1)
+    self.assertEquals(data['users'][0]['id'], fb_user4.uid)
+
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}&return_following={}'.format(1, 1, 'false'))
     data = json.loads(response.data)['data']
     self.assertTrue(len(data['users']) == 1)
     self.assertEquals(data['users'][0]['id'], fb_user4.uid)


### PR DESCRIPTION
This will address  #207
We now have a new parameter return_following which can either be true or false.
If true it the endpoint will function as before and return your friends sorted by the number of followers.
If false it will only return your friends that you are not following also sorted by the number of subscribers