### PR TITLE
Facebook test users now get deleted to prevent rate limiting

### DIFF
--- a/tests/api_utils.py
+++ b/tests/api_utils.py
@@ -8,19 +8,24 @@ from app import app
 from app import constants
 
 def get_facebook_app_access_token():
-    base_uri = 'https://graph.facebook.com/oauth/access_token?client_id={}' \
-        +'&client_secret={}&grant_type=client_credentials'
-    uri = base_uri.format(config.FACEBOOK_APP_ID, config.FACEBOOK_APP_SECRET)
-    response = requests.get(uri).json()
-    return response['access_token']
+  base_uri = 'https://graph.facebook.com/oauth/access_token?client_id={}' \
+      +'&client_secret={}&grant_type=client_credentials'
+  uri = base_uri.format(config.FACEBOOK_APP_ID, config.FACEBOOK_APP_SECRET)
+  response = requests.get(uri).json()
+  return response['access_token']
 
 def create_facebook_user(access_token, username):
-    base_uri = 'https://graph.facebook.com/{}/accounts/test-users?' +\
-        'installed={}&name={}&permissions={}&method=post&access_token={}'
-    uri = base_uri.format(config.FACEBOOK_APP_ID, 'true', username, \
-        constants.FACEBOOK_API_PERMISSIONS, access_token)
-    response = requests.get(uri).json()
-    return response['access_token']
+  base_uri = 'https://graph.facebook.com/{}/accounts/test-users?' +\
+      'installed={}&name={}&permissions={}&method=post&access_token={}'
+  uri = base_uri.format(config.FACEBOOK_APP_ID, 'true', username, \
+      constants.FACEBOOK_API_PERMISSIONS, access_token)
+  response = requests.get(uri).json()
+  return response['access_token'], response['id']
+
+def delete_facebook_user(fb_id, access_token):
+  base_uri = 'https://graph.facebook.com/{}?method=delete&access_token={}'
+  uri = base_uri.format(fb_id, access_token)
+  response = requests.delete(uri).json()
 
 def create_google_user():
   raise NotImplementedError

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -13,8 +13,8 @@ class AccountsTestCase(TestCase):
 
   def test_merge_accounts(self):
     a_access_token = api_utils.get_facebook_app_access_token()
-    u_access_token = api_utils.create_facebook_user(a_access_token, 'User One')
-    self.user1.tokens[constants.FACEBOOK] = u_access_token
+    u_info = api_utils.create_facebook_user(a_access_token, 'User One')
+    self.user1.tokens[constants.FACEBOOK] = u_info[0]
     # Add an account for an invalid platform:
     response = self.user1.post('api/v1/users/merge/?platform={}' \
         .format("fauxbook"))

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -18,3 +18,4 @@ class TestCase(unittest.TestCase):
   def tearDown(self):
     User.query.delete()
     Session.query.delete()
+    remove_test_users()

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -15,9 +15,9 @@ class LoginTestCase(TestCase):
 
   def test_facebook_login(self):
     a_access_token = api_utils.get_facebook_app_access_token()
-    u_access_token = api_utils.create_facebook_user(a_access_token, 'User One')
+    u_info = api_utils.create_facebook_user(a_access_token, 'User One')
     payload = {
-        'access_token': u_access_token
+        'access_token': u_info[0]
     }
     response = self.app.post('api/v1/users/facebook_sign_in/', \
         data=json.dumps(payload))

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -13,6 +13,7 @@ class TestUser(object):
 
   goog_user_count = 0
   default_users = []
+  fb_users = []
 
   # Creates fb_user(graph api) or binds itself to test goog account
   def __init__(self, **kwargs):
@@ -29,7 +30,8 @@ class TestUser(object):
       TestUser.goog_user_count += 1
     else:
       self.app_tokens[constants.FACEBOOK] = app_access_token
-      access_token = create_facebook_user(app_access_token, self.name)
+      access_token, fb_id = create_facebook_user(app_access_token, self.name)
+      self.fb_id = fb_id
       self.tokens[constants.FACEBOOK] = access_token
 
     if kwargs.get('login', True):
@@ -54,6 +56,7 @@ class TestUser(object):
       self.uid = response['user']['id']
       self.user = get_user_by_id(self.uid, self.uid)
       self.session_token = response['session']['session_token']
+      TestUser.fb_users.append(self)
 
   def post(self, url, data=None):
     header = self.init_header()
@@ -117,3 +120,8 @@ def initTestUser():
           followings_count=0,
       )
   ]
+
+def remove_test_users():
+  for user in TestUser.fb_users:
+    delete_facebook_user(user.fb_id, user.app_tokens[constants.FACEBOOK])
+  TestUser.fb_users = []


### PR DESCRIPTION
We now delete the facebook test users we create with every test case.
Since you can only have 2000 total users this will prevent us form being limited and from manually having to delete them once we reach capacity