### PR TITLE
Ignore Friend Recommendations Feature

### DIFF
--- a/src/app/pcasts/__init__.py
+++ b/src/app/pcasts/__init__.py
@@ -47,6 +47,7 @@ from app.pcasts.controllers.search_facebook_friends_controller import *
 from app.pcasts.controllers.get_topics_controller import *
 from app.pcasts.controllers.get_shares_controller import *
 from app.pcasts.controllers.create_delete_share_controller import *
+from app.pcasts.controllers.ignore_facebook_friends_controller import *
 
 controllers = [
     GoogleSignInController(),
@@ -87,7 +88,8 @@ controllers = [
     SearchFacebookFriends(),
     GetTopicsController(),
     GetSharesController(),
-    CreateDeleteShareController()
+    CreateDeleteShareController(),
+    IgnoreFacebookFriendsController(),
 ]
 
 # Setup all controllers

--- a/src/app/pcasts/controllers/get_facebook_friends.py
+++ b/src/app/pcasts/controllers/get_facebook_friends.py
@@ -20,6 +20,7 @@ class GetFacebookFriends(AppDevController):
     return_following = True if return_following == 'true' else False
     fb_friend_ids = facebook_utils.get_friend_ids(user.facebook_id, \
         access_token)
+    fb_friend_ids = users_dao.remove_ignored_ids(fb_friend_ids, user.id)
     users = users_dao.get_users_by_facebook_ids(fb_friend_ids, user.id, \
         offset, max_search, return_following)
 

--- a/src/app/pcasts/controllers/ignore_facebook_friends_controller.py
+++ b/src/app/pcasts/controllers/ignore_facebook_friends_controller.py
@@ -14,4 +14,4 @@ class IgnoreFacebookFriendsController(AppDevController):
     user = kwargs.get('user')
     ignored_fb_id = request.view_args['ignored_fb_id']
     success = users_dao.add_ignored_friend(ignored_fb_id, user.id)
-    return { 'success': success }
+    return {}

--- a/src/app/pcasts/controllers/ignore_facebook_friends_controller.py
+++ b/src/app/pcasts/controllers/ignore_facebook_friends_controller.py
@@ -1,0 +1,17 @@
+import json
+from . import *
+
+class IgnoreFacebookFriendsController(AppDevController):
+
+  def get_path(self):
+    return '/users/facebook/friends/ignore/<ignored_fb_id>/'
+
+  def get_methods(self):
+    return ['POST']
+
+  @authorize
+  def content(self, **kwargs):
+    user = kwargs.get('user')
+    ignored_fb_id = request.view_args['ignored_fb_id']
+    success = users_dao.add_ignored_friend(ignored_fb_id, user.id)
+    return { 'success': success }

--- a/src/app/pcasts/dao/users_dao.py
+++ b/src/app/pcasts/dao/users_dao.py
@@ -163,3 +163,21 @@ def search_facebook_users(facebook_ids, user_id, offset, max_search \
   for u in users:
     u.is_following = is_following_user(user_id, u.id)
   return users
+
+def add_ignored_friend(to_ignore_id, user_id):
+  ignored_ids = IgnoredUsers.query.filter(IgnoredUsers.user_id == user_id).first()
+  if ignored_ids is None:
+    ignored_ids = IgnoredUsers(user_id=user_id, ignored_fb_ids=to_ignore_id)
+  else:
+    ignored_ids.ignored_fb_ids = ignored_ids.ignored_fb_ids + \
+        ",{}".format(to_ignore_id)
+  db_utils.commit_model(ignored_ids)
+  return True
+
+def remove_ignored_ids(fb_friend_ids, user_id):
+  ignored_ids = IgnoredUsers.query.filter(IgnoredUsers.user_id == user_id).first()
+  if ignored_ids is None:
+    return fb_friend_ids
+  else:
+    ignored_ids = [id for id in ignored_ids.ignored_fb_ids.split(',')]
+    return list(set(fb_friend_ids) - set(ignored_ids))

--- a/src/app/pcasts/dao/users_dao.py
+++ b/src/app/pcasts/dao/users_dao.py
@@ -172,12 +172,11 @@ def add_ignored_friend(to_ignore_id, user_id):
     ignored_ids.ignored_fb_ids = ignored_ids.ignored_fb_ids + \
         ",{}".format(to_ignore_id)
   db_utils.commit_model(ignored_ids)
-  return True
 
 def remove_ignored_ids(fb_friend_ids, user_id):
   ignored_ids = IgnoredUsers.query.filter(IgnoredUsers.user_id == user_id).first()
   if ignored_ids is None:
     return fb_friend_ids
   else:
-    ignored_ids = [id for id in ignored_ids.ignored_fb_ids.split(',')]
-    return list(set(fb_friend_ids) - set(ignored_ids))
+    ignored_set = set([id for id in ignored_ids.ignored_fb_ids.split(',')])
+    return [id for id in fb_friend_ids if id not in ignored_set]

--- a/src/app/pcasts/models/_all.py
+++ b/src/app/pcasts/models/_all.py
@@ -10,6 +10,7 @@ from app.pcasts.models.recommendation import *
 from app.pcasts.models.following import *
 from app.pcasts.models.listening_history import *
 from app.pcasts.models.share import *
+from app.pcasts.models.ignored_users import *
 
 class UserSchema(ModelSchema):
   class Meta(ModelSchema.Meta):

--- a/src/app/pcasts/models/ignored_users.py
+++ b/src/app/pcasts/models/ignored_users.py
@@ -1,0 +1,18 @@
+from sqlalchemy import UniqueConstraint
+from . import *
+
+class IgnoredUsers(Base):
+  __tablename__ = 'ignored_users'
+  __table_args__ = (
+      UniqueConstraint('user_id'),
+  )
+
+  user_id = db.Column(db.Integer, \
+      db.ForeignKey('users.id', ondelete='CASCADE'), primary_key=True)
+  ignored_fb_ids = db.Column(db.Text)
+
+  user = db.relationship('User')
+
+  def __init__(self, **kwargs):
+    self.user_id = kwargs.get('user_id')
+    self.ignored_fb_ids = kwargs.get('ignored_fb_ids')

--- a/src/scripts/test_podcast.py
+++ b/src/scripts/test_podcast.py
@@ -2,15 +2,18 @@ import requests
 import json
 
 SESSION_TOKEN = 0
-SERVER_URL = "http://SERVER_URL/api/v1/search/users/A/?offset=0&max=50"
+SERVER_URL = 'localhost:5000'
+SERVER_URL = "http://{}/api/v1/search/users/A/?offset=0&max=50".join(SERVER_URL)
+FB_ACCESS_TOKEN = ""
 
 def make_request():
   body = {"BODY_VAL" : 0}
   header = {"Accept" : "application/json",
             "Content-Type": "application/json",
-            "Authorization": "Bearer {}".join(SESSION_TOKEN)}
+            "Authorization": "Bearer {}".join(SESSION_TOKEN),
+            "AccessToken" : FB_ACCESS_TOKEN}
   response = requests.get(SERVER_URL, headers=header)
   return response
 
-response = post_lot_data()
+response = make_request()
 data = json.loads(response.content)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -28,6 +28,9 @@ class AccountsTestCase(TestCase):
     self.assertEquals(constants.NUM_TEST_USERS, users_dao.get_number_users())
     self.assertTrue(response_data['user']['facebook_id'] != "null")
 
+    # Delete created user where index 1 is the facebook id
+    api_utils.delete_facebook_user(u_info[1] ,a_access_token)
+
   def tearDown(self):
     super(AccountsTestCase, self).tearDown()
     User.query.delete()

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -126,7 +126,7 @@ class FriendsTestCase(TestCase):
     # First ignored user
     response = fb_user1.post('api/v1/users/facebook/friends/ignore/' + \
         '{}/'.format(fb_user2.fb_id))
-    data = json.loads(response.data)['data']
+    data = json.loads(response.data)
     self.assertTrue(data['success'])
 
     # Get friends with 1 ignored
@@ -139,7 +139,7 @@ class FriendsTestCase(TestCase):
     # Second ignored user
     response = fb_user1.post('api/v1/users/facebook/friends/ignore/' + \
         '{}/'.format(fb_user3.fb_id))
-    data = json.loads(response.data)['data']
+    data = json.loads(response.data)
     self.assertTrue(data['success'])
 
     # Get friends with 2 ignored

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -10,11 +10,13 @@ class FriendsTestCase(TestCase):
   def setUp(self):
     super(FriendsTestCase, self).setUp()
     Following.query.delete()
+    IgnoredUsers.query.delete()
     db_session_commit()
 
   def tearDown(self):
     super(FriendsTestCase, self).tearDown()
     Following.query.delete()
+    IgnoredUsers.query.delete()
     db_session_commit()
 
   def test_get_friends(self):
@@ -106,3 +108,42 @@ class FriendsTestCase(TestCase):
     data = json.loads(response.data)['data']
     self.assertTrue(len(data['users']) == 1)
     self.assertEquals(data['users'][0]['id'], fb_user4.uid)
+
+  def test_ignored_friends(self):
+    fb_app_token = api_utils.get_facebook_app_access_token()
+
+    fb_user1 = TestUser(test_client=self.app, platform=constants.FACEBOOK,\
+        app_access_token=fb_app_token, name='FB One')
+    fb_user2 = TestUser(test_client=self.app, platform=constants.FACEBOOK,\
+        app_access_token=fb_app_token, name='FB Two')
+    fb_user3 = TestUser(test_client=self.app, platform=constants.FACEBOOK,\
+        app_access_token=fb_app_token, name='FB Three')
+
+    api_utils.create_facebook_friendship(fb_user1, fb_user2)
+    api_utils.create_facebook_friendship(fb_user1, fb_user3)
+
+    # No ignored tested by regular get friends
+    # First ignored user
+    response = fb_user1.post('api/v1/users/facebook/friends/ignore/' + \
+        '{}/'.format(fb_user2.fb_id))
+    data = json.loads(response.data)['data']
+    self.assertTrue(data['success'])
+
+    # Get friends with 1 ignored
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}'.format(0, 10))
+    data = json.loads(response.data)['data']
+    self.assertTrue(len(data['users']) == 1)
+    self.assertEquals(data['users'][0]['id'], fb_user3.uid)
+
+    # Second ignored user
+    response = fb_user1.post('api/v1/users/facebook/friends/ignore/' + \
+        '{}/'.format(fb_user3.fb_id))
+    data = json.loads(response.data)['data']
+    self.assertTrue(data['success'])
+
+    # Get friends with 2 ignored
+    response = fb_user1.get('api/v1/users/facebook/friends/' + \
+            '?offset={}&max={}'.format(0, 10))
+    data = json.loads(response.data)['data']
+    self.assertTrue(len(data['users']) == 0)


### PR DESCRIPTION
Implements the feature to ignore certain users from your recommended Facebook friends.
Also fixes a leak where we created FB test users and didn't delete them.
