### PR TITLE
jump back in

### DIFF
--- a/src/app/pcasts/__init__.py
+++ b/src/app/pcasts/__init__.py
@@ -47,6 +47,7 @@ from app.pcasts.controllers.search_facebook_friends_controller import *
 from app.pcasts.controllers.get_topics_controller import *
 from app.pcasts.controllers.get_shares_controller import *
 from app.pcasts.controllers.create_delete_share_controller import *
+from app.pcasts.controllers.listening_history_dismiss_controller import *
 
 controllers = [
     GoogleSignInController(),
@@ -87,7 +88,8 @@ controllers = [
     SearchFacebookFriends(),
     GetTopicsController(),
     GetSharesController(),
-    CreateDeleteShareController()
+    CreateDeleteShareController(),
+    ListeningHistoryDismissController()
 ]
 
 # Setup all controllers

--- a/src/app/pcasts/controllers/listening_history_controller.py
+++ b/src/app/pcasts/controllers/listening_history_controller.py
@@ -15,8 +15,15 @@ class ListeningHistoryController(AppDevController):
       user = kwargs.get('user')
       offset = int(request.args['offset'])
       max_hs = int(request.args['max'])
+      dismissed = None
+      if 'dismissed' in request.args:
+        if request.args['dismissed'].lower() == 'false':
+          dismissed = False
+        elif request.args['dismissed'].lower() == 'true':
+          dismissed = True
       histories = \
-        listening_histories_dao.get_listening_history(user, max_hs, offset)
+        listening_histories_dao.get_listening_history(user, max_hs, offset,
+                                                      dismissed=dismissed)
       return {'listening_histories': [listening_history_schema.dump(h).data
                                       for h in histories]}
     elif request.method == 'POST':

--- a/src/app/pcasts/controllers/listening_history_dismiss_controller.py
+++ b/src/app/pcasts/controllers/listening_history_dismiss_controller.py
@@ -1,0 +1,29 @@
+import json
+from . import *
+
+class ListeningHistoryDismissController(AppDevController):
+
+  def get_path(self):
+    return '/history/listening/dismiss/<episode_id>/'
+
+  def get_methods(self):
+    return ['POST']
+
+  @authorize
+  def content(self, **kwargs):
+    user = kwargs.get('user')
+    episode_id = request.view_args['episode_id']
+    dismissed = True
+    if 'dismissed' in request.args:
+      if request.args['dismissed'].lower() == 'false':
+        dismissed = False
+      elif request.args['dismissed'].lower() == 'true':
+        dismissed = True
+    listening_histories_dao.\
+      update_listening_history_dismissed(episode_id, user.id, dismissed)
+    app.logger.info({
+        'user': user.username,
+        'episode_id': episode_id,
+        'message': 'listening history dismissed value set {}'.format(dismissed)
+    })
+    return dict()

--- a/src/app/pcasts/dao/listening_histories_dao.py
+++ b/src/app/pcasts/dao/listening_histories_dao.py
@@ -22,6 +22,7 @@ def create_or_update_listening_histories(episode_update_info_map, user):
       lh = listening_histories_by_episode[episode_id]
       lh.current_progress = current_progress
       lh.percentage_listened = lh.percentage_listened + percentage_listened
+      lh.dismissed = False
     else:
       lh = \
         ListeningHistory(episode_id=episode_id, user_id=user.id,
@@ -56,14 +57,24 @@ def clear_listening_history(user):
     ListeningHistory.query.filter(ListeningHistory.user_id == user.id).all()
   db_utils.delete_models(listening_histories)
 
-def get_listening_history(user, max_hs, offset):
-  listening_histories = ListeningHistory.\
-    query.\
-    filter(ListeningHistory.user_id == user.id).\
-    order_by(ListeningHistory.updated_at.desc()).\
-    limit(max_hs).\
-    offset(offset).\
-    all()
+def get_listening_history(user, max_hs, offset, dismissed=None):
+  if dismissed is None:
+    listening_histories = ListeningHistory.\
+      query.\
+      filter(ListeningHistory.user_id == user.id).\
+      order_by(ListeningHistory.updated_at.desc()).\
+      limit(max_hs).\
+      offset(offset).\
+      all()
+  else:
+    listening_histories = ListeningHistory.\
+      query.\
+      filter(ListeningHistory.user_id == user.id,
+             ListeningHistory.dismissed == dismissed).\
+      order_by(ListeningHistory.updated_at.desc()).\
+      limit(max_hs).\
+      offset(offset).\
+      all()
 
   episodes = \
     episodes_dao.get_episodes([h.episode_id for h in listening_histories],
@@ -74,3 +85,16 @@ def get_listening_history(user, max_hs, offset):
     lh.episode = episode_id_to_episode[lh.episode_id]
 
   return listening_histories
+
+def update_listening_history_dismissed(episode_id, user_id, value):
+  assert value is True or value is False
+  optional_listening_history = ListeningHistory.query.\
+    filter(
+        ListeningHistory.user_id == user_id,
+        ListeningHistory.episode_id == episode_id
+    ).first()
+  if optional_listening_history:
+    optional_listening_history.dismissed = value
+    return db_utils.commit_model(optional_listening_history)
+  else:
+    raise Exception('Specified history does not exist')

--- a/src/app/pcasts/models/listening_history.py
+++ b/src/app/pcasts/models/listening_history.py
@@ -13,6 +13,7 @@ class ListeningHistory(Base):
   episode_id = db.Column(db.Integer, nullable=False)
   percentage_listened = db.Column(db.Float, nullable=False)
   current_progress = db.Column(db.Float, nullable=False)
+  dismissed = db.Column(db.Boolean, nullable=False, default=False)
 
   user = db.relationship('User')
 
@@ -22,3 +23,4 @@ class ListeningHistory(Base):
     self.episode_id = kwargs.get('episode_id')
     self.percentage_listened = kwargs.get('percentage_listened')
     self.current_progress = kwargs.get('current_progress')
+    self.dismissed = kwargs.get('dismissed', False)


### PR DESCRIPTION
Provides the functionality for the "Jump Back In" feature, which pretty much gives the list of most recently listened to episodes but with the ability to dismiss episodes a user doesn't want to continue.

Provides an endpoint for dismissing (or optionally undismissing) an episode, and modifies the current get listening history to have an optional argument `dismissed` that will filter the listening history with the given value.

When a user listens to an episode again (updates the listening history) it automatically undismisses the episode.