### PR TITLE
remove naive series for topic

### DIFF
--- a/src/app/pcasts/controllers/discover_series_for_topic_controller.py
+++ b/src/app/pcasts/controllers/discover_series_for_topic_controller.py
@@ -12,8 +12,8 @@ class DiscoverSeriesForTopicController(AppDevController):
   def content(self, **kwargs):
     user_id = kwargs.get('user').id
     topic_id = request.view_args['topic_id']
-    offset = request.args['offset']
-    max_search = request.args['max']
+    offset = int(request.args['offset'])
+    max_search = int(request.args['max'])
     series = discover_dao.get_series_for_topic(topic_id, user_id, offset, \
         max_search)
     return {'series': [series_schema.dump(s).data for s in series]}

--- a/src/app/pcasts/dao/discover_dao.py
+++ b/src/app/pcasts/dao/discover_dao.py
@@ -15,36 +15,9 @@ def request_podcast_ml(url):
     raise Exception('Could not connect to podcast-ml')
 
 def get_series_for_topic(topic_id, user_id, offset, max_search):
-  if config.ML_ENABLED:
-    series_list = series_for_topic_dao.get_series_list_for_topic(topic_id)
-    return series_dao.get_multiple_series(series_list, user_id)
-  else:
-    topic_id = int(topic_id)
-    series = []
-    # Second ordering by id to resolve ties showing up at different offsets
-    if topic_id in topic_utils.topic_id_offset:
-      topic_id = topic_utils.translate_topic_id(topic_id)
-      series = Series.query.\
-          filter(((Series.topic_id.op('&')(topic_id))) == topic_id).\
-          order_by(Series.subscribers_count.desc()).\
-          order_by(Series.id).\
-          offset(offset).\
-          limit(max_search).\
-          all()
-    elif topic_id in topic_utils.subtopic_id_offset:
-      subtopic_id = topic_utils.translate_subtopic_id(topic_id)
-      series = Series.query.\
-          filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
-          order_by(Series.subscribers_count.desc()).\
-          order_by(Series.id).\
-          offset(offset).\
-          limit(max_search).\
-          all()
-    else:
-      raise Exception("Invalid topic id " + str(topic_id))
-    for s in series:
-      s.is_subscribed = series_dao.is_subscribed_by_user(s.id, user_id)
-    return series
+  series_list = series_for_topic_dao \
+    .get_series_list_for_topic(topic_id, offset, max_search)
+  return series_dao.get_multiple_series(series_list, user_id)
 
 
 def get_episodes_for_topic(topic_id, user_id, offset, max_search):

--- a/src/app/pcasts/dao/series_for_topic_dao.py
+++ b/src/app/pcasts/dao/series_for_topic_dao.py
@@ -1,10 +1,12 @@
 from . import *
 
-def get_series_list_for_topic(tid):
+def get_series_list_for_topic(tid, offset, max_search):
   tid = 1 if tid == 'all' else int(tid)
   optional_model = SeriesForTopic.query \
     .filter(SeriesForTopic.topic_id == tid).first()
   if optional_model:
-    return [int(sid) for sid in optional_model.series_list.split(',')]
+    series_list = [int(sid) for sid in optional_model.series_list.split(',')]
+    end = min(offset + max_search, len(series_list))
+    return series_list[offset:end]
   else:
     raise Exception('No topic id {} exists'.format(tid))


### PR DESCRIPTION
removes the naive top series for topic based on sub count since the itunes based on is not ML based. also fixes some issues with the series for topic tests