### PR TITLE
Kevin/jump back in

### DIFF
--- a/src/app/pcasts/__init__.py
+++ b/src/app/pcasts/__init__.py
@@ -90,11 +90,8 @@ controllers = [
     GetTopicsController(),
     GetSharesController(),
     CreateDeleteShareController(),
-<<<<<<< HEAD
-    ListeningHistoryDismissController()
-=======
+    ListeningHistoryDismissController(),
     IgnoreFacebookFriendsController(),
->>>>>>> master
 ]
 
 # Setup all controllers

--- a/src/app/pcasts/dao/listening_histories_dao.py
+++ b/src/app/pcasts/dao/listening_histories_dao.py
@@ -70,7 +70,9 @@ def get_listening_history(user, max_hs, offset, dismissed=None):
     listening_histories = ListeningHistory.\
       query.\
       filter(ListeningHistory.user_id == user.id,
-             ListeningHistory.dismissed == dismissed).\
+             ListeningHistory.dismissed == dismissed,
+             ListeningHistory.current_progress > 0.01,
+             ListeningHistory.current_progress < 0.99).\
       order_by(ListeningHistory.updated_at.desc()).\
       limit(max_hs).\
       offset(offset).\

--- a/src/app/pcasts/dao/listening_histories_dao.py
+++ b/src/app/pcasts/dao/listening_histories_dao.py
@@ -35,9 +35,9 @@ def create_or_update_listening_histories(episode_update_info_map, user):
     [k for k, v in episode_update_info_map.items() if 'real_duration' in v]
   episodes = episodes_dao.get_episodes(episode_ids_to_query, user.id)
   for episode in episodes:
-    if not episode.real_duration_written:
-      episode.duration = episode_update_info_map[episode.id]['real_duration']
-      episode.real_duration_written = True
+    # if not episode.real_duration_written: DISABLED FOR NOW TO FIX BAD VALUES
+    episode.duration = episode_update_info_map[episode.id]['real_duration']
+    episode.real_duration_written = True
   db_utils.db_session_commit()
   return result
 

--- a/tests/test_listening_history.py
+++ b/tests/test_listening_history.py
@@ -164,7 +164,7 @@ class ListeningHistoryTestCase(TestCase):
     self.assertEquals(len(data['data']['listening_histories']), 0)
 
   def test_dismissed_filter(self):
-    self.generate_listening_histories()
+    episode1_id, episode2_id, _ = self.generate_listening_histories()
 
     # Nothing is dismissed
     response = \
@@ -206,6 +206,27 @@ class ListeningHistoryTestCase(TestCase):
       self.user1.get('api/v1/history/listening/?offset=0&max=5&dismissed=false')
     data = json.loads(response.data)
     self.assertEquals(len(data['data']['listening_histories']), 2)
+
+    # Test 0.01 < current_progress < 0.99 filter
+    data = {
+        episode1_id: {
+            'percentage_listened': 0.5,
+            'current_progress': 0.01,
+        },
+        episode2_id: {
+            'percentage_listened': 0.4,
+            'current_progress': 0.99,
+        },
+    }
+    self.user1.post('api/v1/history/listening/', data=json.dumps(data))
+    response = \
+      self.user1.get('api/v1/history/listening/?offset=0&max=5&dismissed=true')
+    data = json.loads(response.data)
+    self.assertEquals(len(data['data']['listening_histories']), 0)
+    response = \
+      self.user1.get('api/v1/history/listening/?offset=0&max=5&dismissed=false')
+    data = json.loads(response.data)
+    self.assertEquals(len(data['data']['listening_histories']), 0)
 
   def test_automatic_undismiss_on_update(self):
     episode_id, _, _ = self.generate_listening_histories()


### PR DESCRIPTION
Add filter to jump back in endpoint so that we don't return episodes the user has finished or that they have barely listened to. Also temporarily disable the write once check on real episode durations