### PR TITLE
Changed ordering in episode queries to match indices for performance

### DIFF
--- a/src/app/pcasts/dao/discover_dao.py
+++ b/src/app/pcasts/dao/discover_dao.py
@@ -41,7 +41,7 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
           filter((Series.topic_id.op('&')(topic_id)) == topic_id).\
           filter(Episode.series_id == Series.id).\
           order_by(Episode.recommendations_count.desc()).\
-          order_by(Episode.id).\
+          order_by(Episode.id.desc()).\
           offset(offset).\
           limit(max_search).\
           all()
@@ -51,7 +51,7 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
           filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
           filter(Episode.series_id == Series.id).\
           order_by(Episode.recommendations_count.desc()).\
-          order_by(Episode.id).\
+          order_by(Episode.id.desc()).\
           offset(offset).\
           limit(max_search).\
           all()

--- a/src/app/pcasts/dao/episodes_dao.py
+++ b/src/app/pcasts/dao/episodes_dao.py
@@ -97,7 +97,7 @@ def get_top_episodes_by_recommenders(offset, max_search, user_id):
       Episode.query.\
       with_entities(Episode.id, Episode.recommendations_count).\
       order_by(Episode.recommendations_count.desc()).\
-      order_by(Episode.id).\
+      order_by(Episode.id.desc()).\
       offset(offset).\
       limit(max_search).\
       all()


### PR DESCRIPTION
The following PR will solve #235 by optimizing the query to align with the index. 
We currently have an index that sorts entries on recommendation count and breaks ties by id.
The current query searches backwards on recommendation counts but forward on id. 
It has been changed to searches backwards on recommendation counts and backwards on id.

Tests will updated in seperate refactor due to our problem with our tests