### PR TITLE
Dnosrati/utf8mb4

### DIFF
--- a/src/app/pcasts/dao/discover_dao.py
+++ b/src/app/pcasts/dao/discover_dao.py
@@ -41,7 +41,7 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
           filter((Series.topic_id.op('&')(topic_id)) == topic_id).\
           filter(Episode.series_id == Series.id).\
           order_by(Episode.recommendations_count.desc()).\
-          order_by(Episode.id).\
+          order_by(Episode.id.desc()).\
           offset(offset).\
           limit(max_search).\
           all()
@@ -51,7 +51,7 @@ def get_episodes_for_topic(topic_id, user_id, offset, max_search):
           filter((Series.subtopic_id.op('&')(subtopic_id)) == subtopic_id).\
           filter(Episode.series_id == Series.id).\
           order_by(Episode.recommendations_count.desc()).\
-          order_by(Episode.id).\
+          order_by(Episode.id.desc()).\
           offset(offset).\
           limit(max_search).\
           all()

--- a/src/app/pcasts/dao/episodes_dao.py
+++ b/src/app/pcasts/dao/episodes_dao.py
@@ -97,7 +97,7 @@ def get_top_episodes_by_recommenders(offset, max_search, user_id):
       Episode.query.\
       with_entities(Episode.id, Episode.recommendations_count).\
       order_by(Episode.recommendations_count.desc()).\
-      order_by(Episode.id).\
+      order_by(Episode.id.desc()).\
       offset(offset).\
       limit(max_search).\
       all()

--- a/src/app/pcasts/models/episode.py
+++ b/src/app/pcasts/models/episode.py
@@ -10,7 +10,7 @@ class Episode(Base):
   author = db.Column(db.Text)
   summary = db.Column(MEDIUMTEXT)
   pub_date = db.Column(db.DateTime, default=db.func.current_timestamp())
-  duration = db.Column(db.String(255))
+  duration = db.Column(db.String(190))
   real_duration_written = db.Column(db.Boolean, nullable=False)
   audio_url = db.Column(db.Text)
   tags = db.Column(db.Text) # semicolon-separated

--- a/src/app/pcasts/models/series.py
+++ b/src/app/pcasts/models/series.py
@@ -7,8 +7,8 @@ class Series(Base):
 
   id = db.Column(db.Integer, primary_key=True)
   title = db.Column(db.Text)
-  country = db.Column(db.String(255))
-  author = db.Column(db.String(255))
+  country = db.Column(db.String(190))
+  author = db.Column(db.String(190))
   image_url_lg = db.Column(db.Text)
   image_url_sm = db.Column(db.Text)
   feed_url = db.Column(db.Text, nullable=False)

--- a/src/app/pcasts/models/session.py
+++ b/src/app/pcasts/models/session.py
@@ -7,9 +7,9 @@ class Session(Base):
   __tablename__ = 'sessions'
 
   id = db.Column(db.Integer, primary_key=True)
-  session_token = db.Column(db.String(255), unique=True, nullable=False)
+  session_token = db.Column(db.String(190), unique=True, nullable=False)
   expires_at = db.Column(db.DateTime, nullable=False)
-  update_token = db.Column(db.String(255), unique=True, nullable=False)
+  update_token = db.Column(db.String(190), unique=True, nullable=False)
   is_active = db.Column(db.Boolean, nullable=False)
 
   user_id = \

--- a/src/app/pcasts/models/user.py
+++ b/src/app/pcasts/models/user.py
@@ -5,15 +5,15 @@ class User(Base):
   __tablename__ = 'users'
 
   id = db.Column(db.Integer, primary_key=True)
-  google_id = db.Column(db.String(255), unique=True)
-  facebook_id = db.Column(db.String(255), unique=True)
-  email = db.Column(db.String(255), nullable=False)
-  first_name = db.Column(db.String(255))
-  last_name = db.Column(db.String(255))
-  image_url = db.Column(db.String(1500)) # Might have long image URL
+  google_id = db.Column(db.String(190), unique=True)
+  facebook_id = db.Column(db.String(190), unique=True)
+  email = db.Column(db.String(190), nullable=False)
+  first_name = db.Column(db.String(190))
+  last_name = db.Column(db.String(190))
+  image_url = db.Column(db.String(190)) # Might have long image URL
   followers_count = db.Column(db.Integer, nullable=False)
   followings_count = db.Column(db.Integer, nullable=False)
-  username = db.Column(db.String(255), nullable=False, unique=True)
+  username = db.Column(db.String(190), nullable=False, unique=True)
 
   def __init__(self, **kwargs):
     assert kwargs.get('facebook_id') is not None or\


### PR DESCRIPTION
Currently our database is utf8mb4 to support the entire utf8 spectrum(emojis included).
However you can only index onto columns that are less than 767 bytes long(with our current db engine).
That means that with a character being 4 bytes in utf8, a column that needs to be indexed into can only be 767/4 or 190 characters long.
This PR changes all columns that are indexed on to be that size.